### PR TITLE
Fix organisation data scoping

### DIFF
--- a/src/models/ratingSystem.ts
+++ b/src/models/ratingSystem.ts
@@ -28,6 +28,11 @@ const systemRating = mongoose.model(
       type: Boolean,
       default: false,
     },
+    organization: {
+      type: mongoose.Types.ObjectId,
+      ref: 'Organization',
+      required: true,
+    },
    
   })
 );

--- a/src/models/team.model.ts
+++ b/src/models/team.model.ts
@@ -21,6 +21,11 @@ const teamSchema = new Schema(
       required: true,
       default: true,
     },
+    organization: {
+      type: mongoose.Types.ObjectId,
+      ref: 'Organization',
+      required: true,
+    },
   },
   {
     statics: {

--- a/src/resolvers/coordinatorResolvers.ts
+++ b/src/resolvers/coordinatorResolvers.ts
@@ -28,14 +28,9 @@ const manageStudentResolvers = {
           'manager',
           'coordinator',
         ]);
-        return (await User.find({ role: 'user' })).filter((user: any) => {
+        return (await User.find({ role: 'user',organizations:org?.name })).filter((user: any) => {
           return (
-            ((user.cohort == null &&
-              user.organizations.includes(org.name) &&
-              user.organizations.includes(org.name)) ||
-              (user.cohort == undefined &&
-                user.organizations.includes(org.name))) &&
-            user.organizations.includes(org.name)
+            ((user.cohort == null || user.cohort == undefined))
           );
         });
       } catch (error) {

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -279,7 +279,7 @@ const Schema = gql`
       confirmPassword: String!
       token: String!
     ): String!
-    addTeam(name: String!, cohortName: String!): Team!
+    addTeam(name: String!, cohortName: String!, orgToken: String!): Team!
   }
   type ratingSystem {
     id: ID!
@@ -296,15 +296,16 @@ const Schema = gql`
       grade: [String]!
       description: [String]!
       percentage: [String]!
+      orgToken: String!
     ): ratingSystem!
-    deleteRatingSystem(id: ID!): String!
+    deleteRatingSystem(id: ID!, orgToken: String): String!
     makeRatingdefault(id: ID): String!
   }
 
   type Query {
-    getRatingSystems: [ratingSystem]
+    getRatingSystems(orgToken: String!): [ratingSystem]
     getDefaultGrading: [ratingSystem]
-    getRatingSystem(id: ID!): ratingSystem!
+    getRatingSystem(id: ID!, orgToken: String!): ratingSystem!
   }
   type Notifications {
     id: ID!

--- a/src/seeders/ratingSystem.ts
+++ b/src/seeders/ratingSystem.ts
@@ -10,10 +10,10 @@ const seedsystemRatings = async () => {
       description: [
         'Exceed Expectation',
         'Met expectation',
-        'Below Expectation',
+        'Below Expectation'
       ],
       percentage: ['75-100', '50-75', '35-50'],
-      // organization: (await Organization.find())[0]?.id
+      organization: (await Organization.find())[0]?.id
     },
     {
       userId: '2',
@@ -22,9 +22,10 @@ const seedsystemRatings = async () => {
       description: [
         'Exceed Expectation',
         'Met expectation',
-        'Below Expectation',
+        'Below Expectation'
       ],
       percentage: ['75-100', '50-75', '35-50'],
+      organization: (await Organization.find())[1]?.id
     },
   ];
   await systemRating.deleteMany({});

--- a/src/seeders/teams.seed.ts
+++ b/src/seeders/teams.seed.ts
@@ -1,5 +1,7 @@
 import Cohort from '../models/cohort.model';
 import Team from '../models/team.model';
+import { Organization, User } from '../models/user';
+
 
 const seedTeams = async () => {
   const cohort = await Cohort.find();
@@ -7,10 +9,12 @@ const seedTeams = async () => {
     {
       name: 'Team I',
       cohort: cohort[0]?.id,
+      organization: (await Organization.find())[0]?.id,
     },
     {
       name: 'Team II',
       cohort: cohort[0]?.id,
+      organization: (await Organization.find())[1]?.id,
     },
   ];
 


### PR DESCRIPTION
### PR Description
This Pull Request fix organization data collision 
You will be able to see only data that belongs to the organization you are logged in only.
The Issue was on the following dashboard pages 

- Team
- Train
- Grading System
- and Cohorts

### Description of tasks that were expected to be completed
List all the tasks and sub-tasks that were assigned to you or that you assigned yourself. Make sure you check evey completed task.
### Functionality

### How has this been tested?
To test this Pull request follow this 

- Login as one Organization 
- To the dashboard create data that you are going to remember are belonging to the organization you logged in as.
- Then shift from the organization or log out and log new organization 
- First, are you getting same data? If Yes, it's  a big problem if No that is great  We did it.

## By  Example :

-  Log in as Andela organization 
-   Create Team, Cohorts, Programs, Trainee, and Grading System,...
-   Then Log out from Andela Organization 
-   And Log in as organization 2 Organization and do the same 
-   You can see we have different data and data we get belongs to the organization that owns them 

### PR Checklist:
- [ ] Task 1.
- [ ] Task 2.
- [ ] Task 3.
- [ ] Task n.
### Track PR
Trello Link (#DP-?)
### Screenshots (If appropriate)
(Images)
  