### PR TITLE
fix organization data scoping

### DIFF
--- a/src/helpers/organization.helper.ts
+++ b/src/helpers/organization.helper.ts
@@ -7,8 +7,6 @@ export async function checkLoggedInOrganization(token?: string) {
   const SECRET = process.env.SECRET || 'test_secret';
 
   if (!token) {
-    console.log(token, 'token');
-
     throw new AuthenticationError('Not logged in an organization');
   }
 

--- a/src/models/cohort.model.ts
+++ b/src/models/cohort.model.ts
@@ -43,6 +43,11 @@ const cohortSchema = new Schema(
     endDate: {
       type: Date,
     },
+    organization: {
+      type: mongoose.Types.ObjectId,
+      ref: 'Organization',
+      required: true,
+    },
   },
   {
     statics: {

--- a/src/models/ratingSystem.ts
+++ b/src/models/ratingSystem.ts
@@ -28,6 +28,11 @@ const systemRating = mongoose.model(
       type: Boolean,
       default: false,
     },
+    organization: {
+      type: mongoose.Types.ObjectId,
+      ref: 'Organization',
+      required: true,
+    },
    
   })
 );

--- a/src/models/team.model.ts
+++ b/src/models/team.model.ts
@@ -21,6 +21,11 @@ const teamSchema = new Schema(
       required: true,
       default: true,
     },
+    organization: {
+      type: mongoose.Types.ObjectId,
+      ref: 'Organization',
+      required: true,
+    },
   },
   {
     statics: {

--- a/src/resolvers/cohort.resolvers.ts
+++ b/src/resolvers/cohort.resolvers.ts
@@ -78,6 +78,7 @@ const resolvers = {
         programName: string;
         startDate: Date;
         endDate?: Date;
+        orgToken: string;
       },
       context: Context
     ) => {
@@ -89,6 +90,7 @@ const resolvers = {
           programName,
           startDate,
           endDate,
+          orgToken 
         } = args;
 
         // some validations
@@ -96,14 +98,11 @@ const resolvers = {
         const coordinator = await User.findOne({
           email: coordinatorEmail,
         });
+        const organ = await checkLoggedInOrganization(orgToken);
         const program = await Program.findOne({ name: programName });
         const phase = await Phase.findOne({ name: phaseName });
 
         // validate inputs
-        if (await Cohort.findOne({ name })) {
-          throw new ValidationError(`Cohort with name ${name} already exist`);
-        }
-
         if (!phase) {
           throw new ValidationError(
             `Phase with name ${phaseName} doesn't exist`
@@ -130,6 +129,11 @@ const resolvers = {
           throw new ValidationError("End Date can't be before Start Date");
         }
 
+        const findCohort = await Cohort.find({ name, organization: organ?.id });
+        if (findCohort.length) {
+          throw new ValidationError(`Cohort with name ${name} already exist`);
+        }
+
         const org = new Cohort({
           name,
           coordinator: coordinator.id,
@@ -137,6 +141,7 @@ const resolvers = {
           program: program.id,
           startDate,
           endDate,
+          organization: organ?.id
         });
 
         return org.save();
@@ -179,6 +184,8 @@ const resolvers = {
       const coordinator = await User.findOne({
         email: coordinatorEmail,
       });
+
+      const organ = await checkLoggedInOrganization(orgToken);
       const program = await Program.findOne({ name: programName });
       const phase = await Phase.findOne({ name: phaseName });
 
@@ -209,9 +216,10 @@ const resolvers = {
           `Program with name ${programName} doesn't exist`
         );
       }
-      if (name && name !== cohort.name && (await Cohort.findOne({ name }))) {
-        throw new ValidationError(`Cohort with name ${name} already exist`);
+      if (name && name !== cohort.name && (await Cohort.findOne({ name, organization: organ?.id }))) {
+        throw new ValidationError(`Phase with name ${name} already exist`);
       }
+
       if (startDate && differenceInDays(new Date(startDate), Date.now()) < 0) {
         throw new ValidationError("Start Date can't be in the past");
       }

--- a/src/resolvers/coordinatorResolvers.ts
+++ b/src/resolvers/coordinatorResolvers.ts
@@ -28,14 +28,9 @@ const manageStudentResolvers = {
           'manager',
           'coordinator',
         ]);
-        return (await User.find({ role: 'user' })).filter((user: any) => {
+        return (await User.find({ role: 'user',organizations:org?.name })).filter((user: any) => {
           return (
-            ((user.cohort == null &&
-              user.organizations.includes(org.name) &&
-              user.organizations.includes(org.name)) ||
-              (user.cohort == undefined &&
-                user.organizations.includes(org.name))) &&
-            user.organizations.includes(org.name)
+            ((user.cohort == null || user.cohort == undefined))
           );
         });
       } catch (error) {

--- a/src/resolvers/phase.resolver.ts
+++ b/src/resolvers/phase.resolver.ts
@@ -62,19 +62,19 @@ const phaseResolver = {
       ]);
 
       // get the phase and its organization from the id and checks if it exists
+      const organ = await checkLoggedInOrganization(orgToken);
       const phase = await Phase.findById(id).populate('organization');
+
       if (!phase) {
         throw new ValidationError(`Phase with id "${id}" doesn't exist`);
       }
 
+      if (name && name !== phase.name && (await Phase.findOne({ name, organization: organ?.id }))) {
+        throw new ValidationError(`Phase with name ${name} already exist`);
+      }
+
       const phaseOrg = phase?.organization as OrganizationType;
       const org = await checkLoggedInOrganization(orgToken);
-
-      const findPhase = await Phase.find({ name, organization: org?.id });
-
-      if (findPhase.length) {
-        throw new ValidationError(`a phase with name ${name} already exist`);
-      }
 
       // check if a given user have priviledges to update this phase
       if (role !== 'superAdmin') {

--- a/src/schema/cohort.schema.ts
+++ b/src/schema/cohort.schema.ts
@@ -25,6 +25,7 @@ const Schema = gql`
       programName: String!
       startDate: DateTime!
       endDate: DateTime
+      orgToken: String!
     ): Cohort!
     updateCohort(
       id: ID!

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -279,7 +279,7 @@ const Schema = gql`
       confirmPassword: String!
       token: String!
     ): String!
-    addTeam(name: String!, cohortName: String!): Team!
+    addTeam(name: String!, cohortName: String!, orgToken: String!): Team!
   }
   type ratingSystem {
     id: ID!
@@ -296,15 +296,16 @@ const Schema = gql`
       grade: [String]!
       description: [String]!
       percentage: [String]!
+      orgToken: String!
     ): ratingSystem!
-    deleteRatingSystem(id: ID!): String!
+    deleteRatingSystem(id: ID!, orgToken: String): String!
     makeRatingdefault(id: ID): String!
   }
 
   type Query {
-    getRatingSystems: [ratingSystem]
+    getRatingSystems(orgToken: String!): [ratingSystem]
     getDefaultGrading: [ratingSystem]
-    getRatingSystem(id: ID!): ratingSystem!
+    getRatingSystem(id: ID!, orgToken: String!): ratingSystem!
   }
   type Notifications {
     id: ID!

--- a/src/seeders/cohorts.seed.ts
+++ b/src/seeders/cohorts.seed.ts
@@ -1,39 +1,56 @@
 import Cohort from '../models/cohort.model';
 import Phase from '../models/phase.model';
 import Program from '../models/program.model';
-import { User } from '../models/user';
+import { Organization, User } from '../models/user';
 
 const seedCohorts = async () => {
-  const coordinatorId = (await User.findOne({ role: 'coordinator' }))?.id;
   const phases = await Phase.find();
+  const users = await User.find();
+
   const cohorts = [
     {
       name: 'cohort 1',
-      phase: phases[1]?.id,
-      coordinator: coordinatorId,
+      phase: phases[0]?.id,
+      coordinator: users[5]?.id,
       program: (await Program.find())[0].id,
+      teams: 1,
+      active: true,
+      startDate: new Date(),
+      endDate: new Date(),
+      organization: (await Organization.find())[0]?.id
+    },
+    {
+      name: 'cohort 2',
+      phase: phases[1]?.id,
+      coordinator: users[5]?.id,
+      program: (await Program.find())[0].id,
+      teams: 1,
+      active: true,
+      startDate: new Date(),
+      endDate: new Date(),
+      organization: (await Organization.find())[0]?.id
+    },
+    {
+      name: 'cohort 3',
+      phase: phases[2]?.id,
+      coordinator: users[6]?.id,
+      program: (await Program.find())[1].id,
+      teams: 1,
+      active: true,
+      startDate: new Date(),
+      endDate: new Date(),
+      organization: (await Organization.find())[1]?.id
+    },
+    {
+      name: 'cohort 4',
+      phase: phases[2]?.id,
+      coordinator: users[6]?.id,
+      program: (await Program.find())[1].id,
       teams: 2,
       active: true,
       startDate: new Date(),
       endDate: new Date(),
-    },
-    {
-      name: 'cohort 2',
-      phase: phases[0]?.id,
-      coordinator: coordinatorId,
-      program: (await Program.find())[1].id,
-      active: true,
-      startDate: new Date(),
-      endDate: new Date(),
-    },
-    {
-      name: 'cohort 3',
-      phase: phases[0]?.id,
-      coordinator: coordinatorId,
-      program: (await Program.find())[1].id,
-      active: true,
-      startDate: new Date(),
-      endDate: new Date(),
+      organization: (await Organization.find())[1]?.id
     },
   ];
 

--- a/src/seeders/phases.seed.ts
+++ b/src/seeders/phases.seed.ts
@@ -11,6 +11,16 @@ const seedPhases = async () => {
     {
       name: 'Phase II',
       description: 'Team project',
+      organization: (await Organization.find())[0]?.id,
+    },
+    {
+      name: 'Phase I',
+      description: 'Core Concept phase',
+      organization: (await Organization.find())[1]?.id,
+    },
+    {
+      name: 'Phase II',
+      description: 'Team project phase',
       organization: (await Organization.find())[1]?.id,
     },
   ];

--- a/src/seeders/ratingSystem.ts
+++ b/src/seeders/ratingSystem.ts
@@ -10,10 +10,10 @@ const seedsystemRatings = async () => {
       description: [
         'Exceed Expectation',
         'Met expectation',
-        'Below Expectation',
+        'Below Expectation'
       ],
       percentage: ['75-100', '50-75', '35-50'],
-      // organization: (await Organization.find())[0]?.id
+      organization: (await Organization.find())[0]?.id
     },
     {
       userId: '2',
@@ -22,9 +22,10 @@ const seedsystemRatings = async () => {
       description: [
         'Exceed Expectation',
         'Met expectation',
-        'Below Expectation',
+        'Below Expectation'
       ],
       percentage: ['75-100', '50-75', '35-50'],
+      organization: (await Organization.find())[1]?.id
     },
   ];
   await systemRating.deleteMany({});

--- a/src/seeders/teams.seed.ts
+++ b/src/seeders/teams.seed.ts
@@ -1,5 +1,7 @@
 import Cohort from '../models/cohort.model';
 import Team from '../models/team.model';
+import { Organization, User } from '../models/user';
+
 
 const seedTeams = async () => {
   const cohort = await Cohort.find();
@@ -7,10 +9,27 @@ const seedTeams = async () => {
     {
       name: 'Team I',
       cohort: cohort[0]?.id,
+      organization: (await Organization.find())[0]?.id,
     },
     {
       name: 'Team II',
-      cohort: cohort[0]?.id,
+      cohort: cohort[1]?.id,
+      organization: (await Organization.find())[0]?.id,
+    },
+    {
+      name: 'Team III',
+      cohort: cohort[2]?.id,
+      organization: (await Organization.find())[1]?.id,
+    },
+    {
+      name: 'Team IV',
+      cohort: cohort[3]?.id,
+      organization: (await Organization.find())[1]?.id,
+    },
+    {
+      name: 'Team V',
+      cohort: cohort[3]?.id,
+      organization: (await Organization.find())[1]?.id,
     },
   ];
 


### PR DESCRIPTION
### PR Description
This Pull Request fix organization data collision
You will be able to see only data that belongs to the organization you are logged in only.
The Issue was on the following dashboard pages

- Team
- Train
- Grading System
- and Cohorts

### Description of tasks that were expected to be completed
List all the tasks and sub-tasks that were assigned to you or that you assigned yourself. Make sure you check evey completed task.
### Functionality
How does this works, add some information that maybe needed in testing
### How has this been tested?
To test this Pull request follow this

- Login as one Organization
- To the dashboard create data that you are going to remember are belonging to the organization you logged in as.
- Then shift from the organization or log out and log new organization
- First, are you getting same data? If Yes, it's a big problem if No that is great We did it.

## By Example :

- Log in as Andela organization
- Create Team, Cohorts, Programs, Trainee, and Grading System,...
- Then Log out from Andela Organization
- And Log in as organization 2 Organization and do the same
- You can see we have different data and data we get belongs to the organization that owns them


### PR Checklist:
- [x] Task 1.
- [x] Task 2.
- [x] Task 3.
- [x] Task n.
### Track PR
Trello Link (#DP-?)
### Screenshots (If appropriate)
(Images)
  