### PR TITLE
#28-help-page Implement Help

### DIFF
--- a/src/helpers/emailTemplate.helper.ts
+++ b/src/helpers/emailTemplate.helper.ts
@@ -1,13 +1,13 @@
 export default function generateTemplate({
-    message,
-    title = 'Notification Email',
-    link = `${process.env.FRONTEND_LINK}`,
+  message,
+  title = 'Notification Email',
+  link = `${process.env.FRONTEND_LINK}`,
 }: {
   message: string;
   title?: string;
   link?: string;
 }) {
-    return `
+  return `
 <!doctype html>
 <html lang="en-US">
 <head>
@@ -77,5 +77,5 @@ export default function generateTemplate({
     <!-- body table-->
 </body>
 </html>
-`
+`;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import userResolvers from './resolvers/userResolver';
 import ratingResolvers from './resolvers/ratingsResolvers';
 import cohortSchema from './schema/cohort.schema';
 import coordinatorSchema from './schema/coordinator.schema';
+import ticketSchema from './schema/ticket.shema';
 import schemas from './schema/index';
 import programSchema from './schema/program.schema';
 import replyResolver from './resolvers/reply.resolver';
@@ -31,6 +32,7 @@ import { connect } from './database/db.config';
 import { context } from './context';
 import notificationResolver from './resolvers/notification.resolvers';
 import eventResolvers from './resolvers/eventResolver';
+import ticketResolver from './resolvers/ticket.resolver';
 
 export const resolvers = mergeResolvers([
   userResolvers,
@@ -45,6 +47,7 @@ export const resolvers = mergeResolvers([
   teamResolver,
   notificationResolver,
   eventResolvers,
+  ticketResolver,
 ]);
 export const typeDefs = mergeTypeDefs([
   schemas,
@@ -52,9 +55,11 @@ export const typeDefs = mergeTypeDefs([
   programSchema,
   coordinatorSchema,
   phaseSchema,
+  ticketSchema,
 ]);
 
 (async function startApolloServer(typeDefs, resolvers) {
+  console.log(process.env.NODE_ENV);
   // Required logic for integrating with Express
   const app = express();
   const httpServer = http.createServer(app);

--- a/src/models/ticket.model.ts
+++ b/src/models/ticket.model.ts
@@ -1,0 +1,36 @@
+import mongoose, { Schema } from 'mongoose';
+
+const ticketSchema = new Schema(
+  {
+    user: {
+      type: mongoose.Types.ObjectId,
+      ref: 'User',
+      required: true,
+    },
+    subject: {
+      type: String,
+      required: true,
+    },
+    message: {
+      type: String,
+      required: true,
+    },
+    status: {
+      type: String,
+      enum: ['open', 'customer-reply', 'admin-reply', 'closed'],
+      default: 'open',
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+ticketSchema.pre('find', function (next) {
+  this.sort('-createdAt');
+  next();
+});
+
+const Ticket = mongoose.model('Ticket', ticketSchema);
+
+export default Ticket;

--- a/src/resolvers/coordinatorResolvers.ts
+++ b/src/resolvers/coordinatorResolvers.ts
@@ -27,26 +27,26 @@ const manageStudentResolvers = {
           'coordinator',
         ]);
 
-        // Fetch coordinators based on the role 
+        // Fetch coordinators based on the role
         const coordinators = await User.find({
-          role: 'coordinator'
+          role: 'coordinator',
         });
 
         return coordinators || [];
       } catch (error) {
         const { message } = error as { message: any };
-        throw new ApolloError('An error occurred while fetching coordinators.', 'INTERNAL_SERVER_ERROR', {
-          detailedMessage: message.toString(),
-        });
+        throw new ApolloError(
+          'An error occurred while fetching coordinators.',
+          'INTERNAL_SERVER_ERROR',
+          {
+            detailedMessage: message.toString(),
+          }
+        );
       }
     },
 
-
-
-
     getUsers: async (_: any, { orgToken }: any, context: Context) => {
       try {
-
         // coordinator validation
         const { userId, role } = (await checkUserLoggedIn(context))([
           'admin',
@@ -268,7 +268,6 @@ const manageStudentResolvers = {
     },
   },
   Mutation: {
-
     async addMemberToTeam(
       _: any,
       { teamName, email, orgToken }: any,
@@ -285,7 +284,10 @@ const manageStudentResolvers = {
       let org: InstanceType<typeof Organization>;
       org = await checkLoggedInOrganization(orgToken);
 
-      const team: any = await Team.findOne({ organization: org?.id,name:teamName }).populate({
+      const team: any = await Team.findOne({
+        organization: org?.id,
+        name: teamName,
+      }).populate({
         path: 'cohort',
         model: Cohort,
         strictPopulate: false,
@@ -578,42 +580,42 @@ const manageStudentResolvers = {
       let org: InstanceType<typeof Organization>;
       org = await checkLoggedInOrganization(orgToken);
 
-      if(!org.name){
+      if (!org.name) {
         throw new Error('You are not logged into an organization');
       }
 
-      const teamToChange= await Team.findOne({
+      const teamToChange = await Team.findOne({
         organization: org?.id,
         name: removedFromTeamName,
       });
 
-      const newTeam= await Team.findOne({
+      const newTeam = await Team.findOne({
         organization: org?.id,
         name: addedToTeamName,
       });
 
-      const member = await User.findOne({email}).populate({
+      const member = await User.findOne({ email }).populate({
         path: 'team',
         model: Team,
         strictPopulate: false,
       });
 
-      if(member && teamToChange && newTeam){
-        member.team= newTeam?.id;
-        member.cohort= newTeam?.cohort;
+      if (member && teamToChange && newTeam) {
+        member.team = newTeam?.id;
+        member.cohort = newTeam?.cohort;
         await member.save();
-        teamToChange.members=teamToChange?.members.filter((user: any) => {
+        teamToChange.members = teamToChange?.members.filter((user: any) => {
           return user.toString() !== member?.id.toString();
         });
         await teamToChange?.save();
         newTeam?.members.push(member?.id);
         await newTeam?.save();
         return `member with email ${email} is successfully moved from team '${teamToChange?.name}' to team '${newTeam?.name}'`;
-      }else{
+      } else {
         throw new Error('This member does not exist');
       }
     },
-    async inviteUser(_: any, { email, orgToken,type }: any, context: any) {
+    async inviteUser(_: any, { email, orgToken, type }: any, context: any) {
       const { userId, role } = (await checkUserLoggedIn(context))([
         'admin',
         'manager',
@@ -633,7 +635,10 @@ const manageStudentResolvers = {
           expiresIn: '2d',
         });
         const newToken: any = token.replace(/\./g, '*');
-        const link = type=='user' ? `${process.env.REGISTER_FRONTEND_URL}/${newToken}`:`${process.env.REGISTER_ORG_FRONTEND_URL}`;
+        const link =
+          type == 'user'
+            ? `${process.env.REGISTER_FRONTEND_URL}/${newToken}`
+            : `${process.env.REGISTER_ORG_FRONTEND_URL}`;
         const content = inviteUserTemplate(
           org.name,
           user.email,

--- a/src/resolvers/team.resolvers.ts
+++ b/src/resolvers/team.resolvers.ts
@@ -225,10 +225,11 @@ const resolvers = {
       if (!findTeam)
         throw new Error('The Team you want to delete does not exist');
 
-      
-        if(findTeam.members.length > 0){
-          throw new ValidationError(`you can't delete ${findTeam.name} becouse it has members`);
-        }
+      if (findTeam.members.length > 0) {
+        throw new ValidationError(
+          `you can't delete ${findTeam.name} becouse it has members`
+        );
+      }
 
       const cohort = await Cohort.findById(findTeam.cohort);
 
@@ -276,8 +277,11 @@ const resolvers = {
         throw new ValidationError(`team with id "${id}" doesn't exist`);
       }
 
-      
-      if (name && name !== team.name && (await Team.findOne({ name, organization: org?.id }))) {
+      if (
+        name &&
+        name !== team.name &&
+        (await Team.findOne({ name, organization: org?.id }))
+      ) {
         throw new ValidationError(`Team with name ${name} already exist`);
       }
 

--- a/src/resolvers/ticket.resolver.ts
+++ b/src/resolvers/ticket.resolver.ts
@@ -1,0 +1,97 @@
+import { ApolloError, ValidationError } from 'apollo-server';
+import Ticket from '../models/ticket.model';
+import { Context } from '../context';
+import { checkUserLoggedIn } from '../helpers/user.helpers';
+import { Profile, User } from '../models/user';
+import { Notification } from '../models/notification.model';
+
+export type TicketType = InstanceType<typeof Ticket>;
+
+async function getUserData(allTickets: Array<any>) {
+  const tickets = allTickets.map(async (ticket: any) => {
+    const profile = await Profile.findOne({
+      user: ticket?.user?._id,
+    }).lean();
+
+    if (profile) {
+      return {
+        ...ticket,
+        user: {
+          ...ticket.user,
+          firstName: profile.firstName,
+          lastName: profile.lastName,
+        },
+      };
+    } else {
+      return {
+        ...ticket,
+        user: {
+          ...ticket.user,
+          firstName: '',
+          lastName: '',
+        },
+      };
+    }
+  });
+
+  return tickets;
+}
+
+const resolvers = {
+  Query: {
+    getAllTickets: async (_: any, arg: any, context: Context) => {
+      try {
+        (await checkUserLoggedIn(context))(['superAdmin']);
+
+        let tickets = await Ticket.find()
+          .populate({
+            path: 'user',
+            select: 'email',
+          })
+          .lean();
+
+        tickets = await Promise.all(await getUserData(tickets));
+
+        return tickets;
+      } catch (error: any) {
+        throw new ApolloError(error.message, '500');
+      }
+    },
+  },
+
+  Mutation: {
+    createTicket: async (_: any, args: TicketType, context: Context) => {
+      try {
+        const { subject, message }: TicketType = args;
+
+        if (!context.userId) throw new ValidationError('Loggin first');
+
+        const ticket = await Ticket.create({
+          user: context.userId,
+          subject,
+          message,
+        });
+
+        const superAdmin = await User.findOne({ role: 'superAdmin' });
+
+        await Notification.create({
+          receiver: superAdmin?._id,
+          message: `Ticket has been sent to you. ${ticket._id}`,
+          sender: context.userId,
+          read: false,
+          createdAt: new Date(),
+        });
+
+        if (ticket)
+          return {
+            responseMsg:
+              'Your message has been received! We will get back to you shortly.',
+          };
+      } catch (error: any) {
+        throw new ApolloError(error.message, '500');
+      }
+    },
+  },
+};
+
+export default resolvers;

--- a/src/schema/ticket.shema.ts
+++ b/src/schema/ticket.shema.ts
@@ -1,0 +1,35 @@
+import { gql } from 'apollo-server';
+
+const ticketSchema = gql`
+  type Ticket {
+    _id: ID!
+    firstName: String!
+    lastName: String!
+    message: String!
+    email: String!
+    subject: String!
+    status: String!
+    user: UserType
+    createdAt: String
+  }
+
+  type UserType {
+    id: ID!
+    email: String!
+    firstName: String!
+    lastName: String!
+  }
+
+  type CreateTicketResponse {
+    responseMsg: String!
+  }
+
+  type Query {
+    getAllTickets: [Ticket!]!
+  }
+  type Mutation {
+    createTicket(subject: String!, message: String!): CreateTicketResponse!
+  }
+`;
+
+export default ticketSchema;


### PR DESCRIPTION
### PR Description
This PR allow users to send feedback or ask for help.

### Description of tasks that were expected to be completed

- Creating help.
- Getting all helps.

### Functionality
- In your **working directory**, open terminal and run `git fetch origin pull/98/head:ft-help-28-help-page`
- Checkout to **ft-help-28-help-page** branch
- Run `npm run dev`
- In your browser, got to `localhost:4000`
- Open click `Query Your Server`
- Login as manager or coordinator or any other persion and Run `createHelp` mutation. All fields are mandatory **(subject and message)** and returned value is a message with field **responseMsg**
- Then login as superadmin and Run `getAllHelps` query. query can have `subject, message, user{firstname, lastname and email}}`

### PR Checklist:
- [x] Create `getAllHelps` query schema
- [x] Create `createHelp` mutation schema
- [x] Create `createHelp` resolver
- [x] Create `getAllHelps` resolver

### Track PR
Trello Card: [28-help-page](https://trello.com/c/IcpT5BtW/28-help-page)

### Screen Shoots

`Creating Help`

![Screenshot (82)](https://github.com/atlp-rwanda/atlp-pulse-bn/assets/55640083/23bc78bd-bfe0-420b-97a5-3ced0a12aad8)

`List of all helps`

![Screenshot (81)](https://github.com/atlp-rwanda/atlp-pulse-bn/assets/55640083/291651ab-55ea-406b-b844-85ea0ec799cc)
