### PR TITLE
feat:Upload resume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+
 # setup docker file for the project
 FROM  node:18-alpine
 WORKDIR /app

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": " npm run seed && tsc && nyc mocha",
     "lint": "eslint src --fix .",
     "format": "npx prettier --write .",
-    "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\""
+    "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\"",
+    "kill": "sudo kill -9 $(sudo lsof -t -i :4000)"
   },
   "mocha": {
     "extension": [

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -126,6 +126,9 @@ const profileSchema = new Schema(
     githubUsername: {
       type: String,
     },
+    resume: {
+      type: String,
+    },
   },
   {
     toJSON: { virtuals: true },

--- a/src/resolvers/profileResolver.ts
+++ b/src/resolvers/profileResolver.ts
@@ -64,6 +64,35 @@ const profileResolvers: any = {
     },
   },
   Mutation: {
+
+
+    uploadResume: async (parent: any, args: any, context: Context) => {
+      try {
+        const { userId, resume } = args;
+        
+       
+        if (!context.userId || context.userId !== userId) {
+          throw new Error('Unauthorized. You can only upload your own resume.');
+        }
+
+       
+        const profile = await Profile.findOne({ user: userId });
+
+        if (!profile) {
+          throw new Error('Profile not found for the user.');
+        }
+
+     
+        profile.resume = resume;
+        await profile.save();
+
+        return profile;
+      } catch (error) {
+        throw new Error('Failed to upload resume: ' + error);
+      }
+    },
+
+
     updateProfile: async (parent: any, args: any, context: any) => {
       try {
         const {

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -95,6 +95,7 @@ const Schema = gql`
     cover: String
     activity: [Activity]
     githubUsername: String
+    resume:String
   }
   type Activity {
     date: String!
@@ -275,6 +276,7 @@ const Schema = gql`
 
   type Mutation {
     createUserRole(name: String!): UserRole!
+    uploadResume(userId: ID!, resume: String!): Profile
     createUser(
       firstName: String!
       lastName: String!


### PR DESCRIPTION

### PR Description
- Add resume to the profileSchema in models
- Create uploadResume Mutation
- Add uploadResume in profileResolvers 
### Description of tasks that were expected to be completed
- Resume documents can be uploaded to the servers
- External links (e.g. to google drive) can also be added
- Coordinators and admin can view each trainee's resume

### Functionality
When the user is updating the profile, he/she can upload a resume or add an external link that leads to his/her resume
### How has this been tested?
- Clone the repo
- checkout the `` upload-resume`` branch
- run the server
- Go to appolo-graphql studio
- Login organization
- Login as a user and return user id
- Run a mutation of uploadResume that should return a profile with resume

### PR Checklist:
- [ ] Task 1.
- [x] Task 2.
- [ ] Task 3.
- [ ] Task n.
### Track PR
Trello Link (#DP-?)
### Screenshots (If appropriate)
(Images)
  