### PR TITLE
fixing get trainees

### DIFF
--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -76,6 +76,12 @@ userSchema.virtual('profile', {
   localField: '_id',
 })
 
+userSchema.virtual('ratings', {
+  localField: '_id',
+  foreignField: 'user',
+  ref: 'Rating',
+})
+
 userSchema.methods.checkPass = async function (password: string) {
   const pass = await bcrypt.compare(password, this.password)
   return pass

--- a/src/resolvers/userResolver.ts
+++ b/src/resolvers/userResolver.ts
@@ -22,6 +22,7 @@ import Team from '../models/team.model'
 import Phase from '../models/phase.model'
 import { Octokit } from '@octokit/rest'
 import { checkloginAttepmts } from '../helpers/logintracker'
+import { Rating } from '../models/ratings'
 const octokit = new Octokit({ auth: `${process.env.GITHUB_TOKEN}` })
 
 const SECRET: string = process.env.SECRET ?? 'test_secret'
@@ -974,13 +975,27 @@ const resolvers: any = {
         return cohort
       }
     },
-
     async team(parent: UserType) {
       const team = await Team.findOne({ members: parent._id })
       if (!team) {
         return null
       } else {
         return team
+      }
+    },
+    async ratings(parent: UserType) {
+      const ratings = await Rating.find({ user: parent._id }).populate([
+        'user',
+        'cohort',
+        {
+          path: 'feedbacks',
+          populate: 'sender',
+        },
+      ])
+      if (!ratings) {
+        return null
+      } else {
+        return ratings
       }
     },
   },

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -63,6 +63,7 @@ const Schema = gql`
     pushNotifications: Boolean!
     emailNotifications: Boolean!
     status: StatusType
+    ratings: [Rating]
   }
   input RegisterInput {
     email: String!

--- a/src/seeders/users.seed.ts
+++ b/src/seeders/users.seed.ts
@@ -234,12 +234,12 @@ const seedUsers = async () => {
   const dbUsers = await User.find().select('_id email')
 
   // For every db user, generate a profile
-  for (let i = 0; i < dbUsers.length; i++) {
-    const userProfile = users.find((user) => user.email === dbUsers[i].email)
+  for (const element of dbUsers) {
+    const userProfile = users.find((user) => user.email === element.email)
 
     if (userProfile) {
       profiles.push({
-        user: dbUsers[i]._id,
+        user: element._id,
         firstName: userProfile.firstName,
         lastName: userProfile.lastName,
         githubUsername: userProfile


### PR DESCRIPTION
### PR Description
- fixing getting trainees query
### Description of tasks that were expected to be completed
- trainees query is returning ratings, as mentioned in issue [282](https://github.com/atlp-rwanda/atlp-pulse-fn/issues/282) in frontend
### Functionality
- trainees are being returned in query with their ratings
### How has this been tested?
- **with `sandbox`**
   - select `getTrainees` query 
   - select to get ratings in return
   - add all required variables 
- **with `front-end`
   - jump on deployed version of the front end https://metron-devpulse-git-fix-trainees-metron.vercel.app/
### PR Checklist:
- [x] returning ratings in `getTrainees` query
### Track PR
issue [282](https://github.com/atlp-rwanda/atlp-pulse-fn/issues/282) in frontend
### Screenshots (If appropriate)
n/a
  