### PR TITLE
 feat Create session functionality

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import eventResolvers from './resolvers/eventResolver'
 import ticketResolver from './resolvers/ticket.resolver'
 import DocumentationResolvers from './resolvers/DocumentationResolvers'
 import attendanceResolver from './resolvers/attendance.resolvers'
+import Sessionresolvers from './resolvers/session.resolver'
 
 export const resolvers = mergeResolvers([
   userResolvers,
@@ -50,6 +51,7 @@ export const resolvers = mergeResolvers([
   ticketResolver,
   DocumentationResolvers,
   attendanceResolver,
+  Sessionresolvers,
 ])
 export const typeDefs = mergeTypeDefs([
   schemas,

--- a/src/models/session.model.ts
+++ b/src/models/session.model.ts
@@ -1,0 +1,28 @@
+import mongoose, { Schema } from 'mongoose';
+
+const sessionSchema = new Schema({
+  Sessionname: {
+    type: String,
+    required: true,
+  },
+  description: {
+    type: String,
+    required: true,
+  },
+  platform: {
+    type: String,
+    required: true,
+  },
+  duration: {
+    type: String,
+    required: true,
+  },
+  organizer: {
+    type: String,
+    required: true,
+  },
+});
+
+const Session = mongoose.model('Session', sessionSchema);
+
+export default Session;

--- a/src/resolvers/session.resolver.ts
+++ b/src/resolvers/session.resolver.ts
@@ -1,0 +1,69 @@
+import Session from '../models/session.model';
+
+const Sessionresolvers = {
+  Query: {
+    getSession: async (_: any, { id }: any) => {
+      return await Session.findById(id);
+    },
+    getAllSessions: async () => {
+      return await Session.find();
+    },
+  },
+  Mutation: {
+    createSession: async (_:any, { sessionInput: { Sessionname, description,  platform,duration, organizer} }:any) => {
+      const createdSession = new Session({
+        Sessionname: Sessionname,
+        description: description,
+        platform:platform,
+        duration:duration,
+        organizer:organizer
+        
+    
+      });
+    
+      try {
+        const res = await createdSession.save();
+        return {
+          id: res._id.toString(),
+          Sessionname: res.Sessionname,
+          description: res.description,
+          platform:res.platform,
+          duration:res.duration,
+          organizer:res.organizer 
+        };
+      } catch (error) {
+         console.error("Failed to create new session:", error);
+        throw new Error("Failed to create new session");
+      }
+    },
+    
+    deleteSession: async (_:any, { ID }:any) => {
+      const wasDeleted = (await Session.deleteOne({ _id: ID })).deletedCount;
+      return wasDeleted === 1;
+    },
+    editSession: async (_: any, { ID, editSessionInput: { Sessionname, description, platform, duration, organizer } }: any) => {
+      const session = await Session.findById(ID);
+    
+      if (!session) {
+        throw new Error("Session not found");
+      }
+    
+      session.Sessionname = Sessionname;
+      session.description = description;
+      session.platform = platform;
+      session.duration = duration;
+      session.organizer = organizer;
+    
+      try {
+        await session.save();
+        return true;
+      } catch (error) {
+        console.error("Failed to update session:", error);
+        throw new Error("Failed to update session");
+      }
+    },
+    
+  },
+};
+
+export default Sessionresolvers;

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -628,5 +628,42 @@ const Schema = gql`
     traineeId: ID!
     status: [StatusInput]
   }
+  type Session {
+    id:String
+    Sessionname: String
+    description: String
+    platform: String
+    duration: String
+    organizer: String
+    
+  }
+  
+  input SessionInput {
+    Sessionname: String
+    description: String
+    platform: String
+    duration: String
+    organizer: String
+
+  }
+  
+  input EditSessionInput {
+    Sessionname: String
+    description: String
+    platform: String
+    duration: String
+    organizer: String
+  }
+  type Query {
+    session(ID: ID!): Session!
+    getSession(id: ID!): Session
+    getAllSessions: [Session] 
+  }
+  
+  type Mutation {
+    createSession(sessionInput: SessionInput): Session!
+    deleteSession(ID: ID!): Boolean
+    editSession(ID: ID!, editSessionInput: EditSessionInput): Boolean
+  }
 `
 export default Schema

--- a/src/seeders/session.seed.ts
+++ b/src/seeders/session.seed.ts
@@ -1,0 +1,28 @@
+import Session from '../models/session.model';
+
+const seedSessions = async () => {
+  const sessionsToSeed = [
+    {
+      Sessionname: 'Session 1',
+      description: 'Description for Session 1',
+      platform: 'Platform A',
+      duration: '1 hour',
+      organizer: 'Organizer X',
+    },
+    {
+      Sessionname: 'Session 2',
+      description: 'Description for Session 2',
+      platform: 'Platform B',
+      duration: '2 hours',
+      organizer: 'Organizer Y',
+    },
+    // Add more session objects as needed
+  ];
+
+  await Session.deleteMany({});
+
+  await Session.insertMany(sessionsToSeed);
+  return null;
+};
+
+export default seedSessions;

--- a/src/utils/templates/inviteUserTemplate.ts
+++ b/src/utils/templates/inviteUserTemplate.ts
@@ -32,6 +32,8 @@ export default function Template(orgName: string, link: string) {
               >
                 Join ${orgName}
               </button>
+              <p>If the button is not functional, copy and paste the link below: </p>
+              ${link}
             </a>
             <br />
             <br />


### PR DESCRIPTION
### PR Description
Create session functionality for trainees.

### Description of tasks that were expected to be completed
This PR introduces the ability to create, retrieve, update, and delete sessions for trainees. The session entity includes fields such as Session Name, Duration, Description, and Organizer.

### Functionality
- Create a new session with Session Name, Duration, Description, and Organizer.
- Retrieve a list of existing sessions.
- Update session details.
- Delete sessions.

### How has this been tested?
1. Checked out the `feat-create-session` branch.
2. Ran `npm install` to install dependencies.
3. Executed `npm run dev` to test the changes.

### PR Checklist:
- [x] Implement session creation.
- [x] Implement session retrieval.
- [x] Implement session update.
- [x] Implement session deletion.

### Track PR
Trello Link (#DP-?)

### Screenshots (If appropriate)
(Images)

