### PR TITLE
fix retrieving and reply tickets on admin panel

### DIFF
--- a/src/resolvers/attendance.resolvers.ts
+++ b/src/resolvers/attendance.resolvers.ts
@@ -108,7 +108,6 @@ const attendanceResolver = {
         const traineeIndex = attendances[weekIndex].trainees.findIndex(
           (item: any) => item.traineeId.includes(trainee.traineeId)
         )
-
         if (traineeIndex !== -1) {
           const attendanceIndex = attendances[weekIndex].trainees[
             traineeIndex

--- a/src/resolvers/ticket.resolver.ts
+++ b/src/resolvers/ticket.resolver.ts
@@ -123,7 +123,15 @@ const resolvers = {
 
         const filterObj: any = {}
 
-        if (context.role !== 'superAdmin') filterObj.user = context.userId
+        // if (context.role !== 'superAdmin') filterObj.user = context.userId
+        if (context.role === 'superAdmin') {
+          // SuperAdmin can view all tickets
+        } else if (context.role === 'admin') {
+          // Admin can view all tickets
+        } else {
+          // Regular user can only view their own tickets
+          filterObj.user = context.userId
+        }
 
         const tickets = await Ticket.find(filterObj)
           .populate({
@@ -223,12 +231,14 @@ const resolvers = {
           )
 
         const { user } = ticket
+        // Allow both superAdmin and admin to reply to the ticket
         if (
-          user?.toString() !== context.userId &&
-          context.role !== 'superAdmin'
+          context.role !== 'superAdmin' &&
+          context.role !== 'admin' &&
+          user?.toString() !== context.userId
         )
           throw new ValidationError(
-            'Access denied! You can only reply if you are the owner of ticket, or you are the super admin.'
+            'Access denied! You can only reply if you are the owner of the ticket, or you are an admin/super admin.'
           )
 
         const res = await createReply(


### PR DESCRIPTION
### PR Description
when a user sent tickets ,admin was not able to view or to reply ticket which has been sent .
### Description of tasks that were expected to be completed
- admin can be able to retrieve tickets
- admin can be able to reply the ticket which has been sent 
### Functionality
added ability that allow admin to view and reply  tickets which has been sent 
### How has this been tested?

1. Cloned the repository using git clone **fix-retrieve/reply-tickets-adminpanel**
2. Installed necessary dependencies using npm install
3. Test by sending Tickets and login as admin check view tickets and be able to reply it 

### PR Checklist:
- [ ] Task 1.
- [ ] Task 2.
- [ ] Task 3.
- [ ] Task n.
### Track PR
Trello Link (#DP-?)
### Screenshots (If appropriate)
(Images)
![viewtickets](https://github.com/atlp-rwanda/atlp-pulse-bn/assets/77956577/b20ebd1c-907b-4def-ab64-6def6bd1bfd8)


  