### PR TITLE
Fixing create cohort

### DIFF
--- a/src/resolvers/cohort.resolvers.ts
+++ b/src/resolvers/cohort.resolvers.ts
@@ -119,9 +119,7 @@ const resolvers = {
             `Program with name ${programName} doesn't exist`
           )
         }
-        if (differenceInDays(new Date(startDate), Date.now()) < 0) {
-          throw new ValidationError('Start Date can\'t be in the past');
-        }
+        
         if (
           endDate &&
           isAfter(new Date(startDate.toString()), new Date(endDate.toString()))
@@ -224,9 +222,7 @@ const resolvers = {
         throw new ValidationError(`Phase with name ${name} already exist`)
       }
 
-      if (startDate && differenceInDays(new Date(startDate), Date.now()) < 0) {
-        throw new ValidationError('Start Date can\'t be in the past');
-      }
+      
       if (
         endDate &&
         (isAfter(


### PR DESCRIPTION
### PR Description

Cohort is able to be added or updated and set the starting time of Cohort to be in the past.

### Description of tasks that were expected to be completed

The task was to be able to add or update the Cohort and be able  to set the starting date of cohort to be in the past.

### Functionality

Super admin, admin, and manager are able to add or update the cohort and be able to set the date of starting time to be in the past.

### How has this been tested?

Super admin, admin, and manager are able to login and navigate to the cohort and be able to add or update the cohort and set the starting time to be in the past.

### PR Checklist:

- Login as a super admin.
- Click on Cohort.
- Fill out the form  to add the cohort or choose update cohort 
- For example use this email [kylesjet1@gmail.com].
- Click save.

### Track PR
Trello Link (#DP-?)
### Screenshots (If appropriate)
![Screen Shot 2023-11-15 at 19 11 35](https://github.com/atlp-rwanda/atlp-pulse-bn/assets/77435896/16f40040-5f33-4a64-a4c2-0a64e634f848)
![Screen Shot 2023-11-15 at 19 14 08](https://github.com/atlp-rwanda/atlp-pulse-bn/assets/77435896/46d79499-b315-41dc-b4a9-d28ddd22c3a7)
