### PR TITLE
Getting coordinators after checking the organisation token

### DIFF
--- a/src/resolvers/coordinatorResolvers.ts
+++ b/src/resolvers/coordinatorResolvers.ts
@@ -34,16 +34,16 @@ enum UserRoles {
 
 const manageStudentResolvers = {
   Query: {
-    getAllCoordinators: async (_: any, __: any, context: Context) => {
+    getAllCoordinators: async (_: any, { orgToken }: any, context: Context) => {
       try {
         // coordinator validation
         ;(await checkUserLoggedIn(context))(['admin', 'manager', 'coordinator'])
-
+        const selectedOrganization = await checkLoggedInOrganization(orgToken)
         // Fetch coordinators based on the role
         const coordinators = await User.find({
           role: 'coordinator',
+          organizations: selectedOrganization.name,
         })
-
         return coordinators || []
       } catch (error) {
         const { message } = error as { message: any }
@@ -62,7 +62,7 @@ const manageStudentResolvers = {
         // coordinator validation
         ;(await checkUserLoggedIn(context))(['admin', 'manager', 'coordinator'])
 
-        // get the organization if someone  logs in
+        // get the organization if someone logs in
         const org: InstanceType<typeof Organization> =
           await checkLoggedInOrganization(orgToken)
 

--- a/src/schema/coordinator.schema.ts
+++ b/src/schema/coordinator.schema.ts
@@ -6,7 +6,7 @@ const Schema = gql`
     getCohorts(orgToken: String): [Cohort]
     getTrainees(orgToken: String): [User]
     getCohortTrainees(orgToken: String, cohort: String): [User]
-    getAllCoordinators: [User]
+    getAllCoordinators(orgToken: String): [User]
   }
   type Message {
     message: String

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -272,7 +272,7 @@ const Schema = gql`
     getAllTTLUsers(orgToken: String): [User]
     getTTLTrainees(orgToken: String): [User]
     getUsers(orgToken: String): [User]
-    getAllCoordinators: [User]
+    getAllCoordinators(orgToken: String): [User]
     getProfile: Profile
     getAllRoles: [UserRole]
     getRole(id: ID!): UserRole


### PR DESCRIPTION
# PR Description
Admin from specific company can be able to see the coordinators from that company only

# Description of tasks that were expected to be completed

My task was for the admin to be able to log in and be able to get coordinators from his company only.

# How has this been tested?

You have to select a specific company. After, you have to include the admin credentials to log in. Then, you have to go in coordinators and be able to see coordinators from your company only

