### PR TITLE
#469 Admin Should be able to cancel a sent invitation

### DIFF
--- a/src/helpers/cancelInvitationEmail.ts
+++ b/src/helpers/cancelInvitationEmail.ts
@@ -1,0 +1,27 @@
+import { sendEmail } from '../utils/sendEmail'
+import cancelInvitationTemplate from '../utils/templates/cancelInvitationTemplate'
+
+export default async function sendCancelInvitationEmail(
+  email: string,
+  orgName: string
+) {
+  try {
+    const content = cancelInvitationTemplate(orgName)
+    await sendEmail(
+      email,
+      'Invitation Cancelled',
+      content,
+      null,
+      process.env.ADMIN_EMAIL,
+      process.env.ADMIN_PASS
+    )
+
+    return { success: true, email }
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      return { success: false, email, error: error.message }
+    } else {
+      return { success: false, email, error: 'Unknown error' }
+    }
+  }
+}

--- a/src/helpers/sendInvitaitonEmail.ts
+++ b/src/helpers/sendInvitaitonEmail.ts
@@ -4,11 +4,11 @@ import updateInvitationTemplate from '../utils/templates/updateInvitationTemplat
 import { Role } from '../resolvers/invitation.resolvers';
 import  jwt  from 'jsonwebtoken';
 
-interface Payload{
-  role:Role,
-  org:{name:string},
-  userId:string,
-  orgToken:string
+interface Payload {
+  role: Role
+  org: { name: string }
+  userId: string
+  orgToken: string
 }
 const SECRET: string = process.env.SECRET ?? 'test_secret'
 export default async function sendInvitationEmail(
@@ -28,15 +28,14 @@ export default async function sendInvitationEmail(
       null,
       process.env.ADMIN_EMAIL,
       process.env.ADMIN_PASS
-    );
+    )
 
-    return { success: true, email };
+    return { success: true, email }
   } catch (error: unknown) {
     if (error instanceof Error) {
-      return { success: false, email, error: error.message };
+      return { success: false, email, error: error.message }
     } else {
-      return { success: false, email, error: 'Unknown error' };
+      return { success: false, email, error: 'Unknown error' }
     }
   }
 }
-  

--- a/src/models/invitation.model.ts
+++ b/src/models/invitation.model.ts
@@ -1,22 +1,23 @@
 import mongoose, { Schema } from 'mongoose'
 
 const STATUS = {
-  PENDING: 'pending', 
-  ACCEPTED: 'accepted', 
-  DENIED: 'denied'
+  PENDING: 'pending',
+  ACCEPTED: 'accepted',
+  DENIED: 'denied',
+  CANCELLED: 'cancelled',
 }
 
 const ROLE = {
   TRAINEE: 'trainee',
   ADMIN: 'admin',
   TTL: 'ttl',
-  COORDINATOR: 'coordinator'
+  COORDINATOR: 'coordinator',
 }
 const InvitationSchema = new Schema({
   inviterId: {
     type: mongoose.Types.ObjectId,
     ref: 'User',
-    required:true
+    required: true,
   },
   status: {
     type: String,
@@ -32,14 +33,13 @@ const InvitationSchema = new Schema({
       role: {
         type: String,
         enum: ROLE,
-        default: ROLE.TRAINEE, 
+        default: ROLE.TRAINEE,
       },
-            
     },
   ],
-  orgToken:{
-    type:String,
-    required:true
+  orgToken: {
+    type: String,
+    required: true,
   },
   invitationToken:{
     type: String,
@@ -49,7 +49,7 @@ const InvitationSchema = new Schema({
     type: Date,
     default: Date.now,
     required: true,
-  }
+  },
 })
 
 const Invitation = mongoose.model('Invitation', InvitationSchema)

--- a/src/resolvers/invitationStatics.resolvers.ts
+++ b/src/resolvers/invitationStatics.resolvers.ts
@@ -7,6 +7,8 @@ interface InvitationStatistics {
   pendingInvitationsCount: number
   getAcceptedInvitationsPercentsCount: number
   getPendingInvitationsPercentsCount: number
+  getCancelledInvitationsPercentsCount: number
+  cancelledInvitationsCount: number
 }
 
 interface QueryArguments {
@@ -50,8 +52,10 @@ const StatisticsResolvers = {
             totalInvitations: 0,
             acceptedInvitationsCount: 0,
             pendingInvitationsCount: 0,
+            cancelledInvitationsCount: 0,
             getAcceptedInvitationsPercentsCount: 0,
             getPendingInvitationsPercentsCount: 0,
+            getCancelledInvitationsPercentsCount: 0,
           }
         }
 
@@ -68,14 +72,22 @@ const StatisticsResolvers = {
           (inv) => inv.status == 'pending'
         ).length
 
+        // CALCULATE CANCELLED INVITATION COUNT
+        const cancelledInvitationsCount = await invitations.filter(
+          (inv) => inv.status == 'cancelled'
+        ).length
+
         return {
           totalInvitations,
           acceptedInvitationsCount,
           pendingInvitationsCount,
+          cancelledInvitationsCount,
           getAcceptedInvitationsPercentsCount:
             (acceptedInvitationsCount / totalInvitations) * 100,
           getPendingInvitationsPercentsCount:
             (pendingInvitationsCount / totalInvitations) * 100,
+          getCancelledInvitationsPercentsCount:
+            (cancelledInvitationsCount / totalInvitations) * 100,
         }
       } catch (error) {
         //

--- a/src/schema/invitation.schema.ts
+++ b/src/schema/invitation.schema.ts
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag';
+import gql from 'graphql-tag'
 
 const invitationSchema = gql`
   scalar Upload
@@ -7,6 +7,7 @@ const invitationSchema = gql`
     pending
     accepted
     denied
+    cancelled
   }
 
   enum Role {
@@ -79,7 +80,8 @@ const invitationSchema = gql`
     updateInvitation(invitationId: ID!, orgToken: String!, newEmail: String, newRole: String): Invitation
     uploadInvitationFile(file: Upload!, orgToken: String!): FileData!
     deleteInvitation(invitationId: ID!): DeleteMessage
+    cancelInvitation(orgToken: String!, id: ID!): Invitation!
   }
 `;
 
-export default invitationSchema;
+export default invitationSchema

--- a/src/schema/invitationStatics.schema.ts
+++ b/src/schema/invitationStatics.schema.ts
@@ -7,6 +7,8 @@ const statisticsSchema = gql`
     pendingInvitationsCount: Int!
     getAcceptedInvitationsPercentsCount: Float!
     getPendingInvitationsPercentsCount: Float!
+    cancelledInvitationsCount: Int!
+    getCancelledInvitationsPercentsCount: Float!
   }
   type Query {
     getInvitationStatistics(

--- a/src/utils/templates/cancelInvitationTemplate.ts
+++ b/src/utils/templates/cancelInvitationTemplate.ts
@@ -1,0 +1,27 @@
+export default function cancelInvitationTemplate(orgName: string): string {
+  return `
+    <table style="border: 1px solid #ddd; padding: 16px; border-radius: 8px; background-color: #f9f9f9; max-width: 600px; margin: 0 auto; font-family: 'Rubik', sans-serif;">
+          <!-- Icon Container -->
+          <tr>
+              <td style="width: 100%; background-color: #FFD3D3; padding: 16px; text-align: center;">
+                  <table width="100%" border="0" cellpadding="16" cellspacing="0" style="border-radius: 8px 8px 0 0;">
+                      <tr>
+                          <td style="text-align: center;">
+                              <img src="https://res.cloudinary.com/ddf0u9tgz/image/upload/v1724949908/emailLogo_rmmwdi.png" style="width: 200px; height: 200px;" alt="Logo" />
+                              <p style="margin: 10px 0 0; font-size: 18px; font-weight: bold; color: #FF0000;">Invitation Cancelled</p>
+                          </td>
+                      </tr>
+                  </table>
+              </td>
+          </tr>
+          <!-- Message Container -->
+          <tr>
+              <td style="padding: 16px; color: black; text-align: left;">
+                  <p>Hello,</p>
+                  <p>We regret to inform you that the invitation to join <strong>${orgName}</strong> has been cancelled.</p>
+                  <p>If you have any questions, feel free to contact us.</p>
+              </td>
+          </tr>
+      </table>
+      `
+}


### PR DESCRIPTION
### PR Description
this PR contains new feature of cancelling an invitatation by Admin
### Description of tasks that were expected to be completed
- [x] branch creation.
- [x] add `cancelled ` status in model
- [x] create cancelInvitation function and it's mutation
- [ ] after cancelling invitation, an email is sent
- [x] add cancelInvitation in invitation statistics
### Functionality
- clone the repository
- `git checkout ft-cancel-invite-469`
- `npm i` and `npm run dev`
-  test invitation mutations and querries
### How has this been tested?
Tested on apolloGraphql after running `npm run dev`, first log an organisation in, then an admin, and finallt test the mutation to cancel invitation and querries to get all invitation, and statistics
### PR Checklist:
 -  [ ] My code follows the style guidelines of this project
 -  [x] I have performed a self-review of my code
 -  [ ]  I have commented my code, particularly in hard-to-understand areas
 -  [ ] My code generate no warnings
 -  [ ] My test coverage meet the set test coverage threshold
 -  [ ] There are no vulnerabilities
 -  [x] There are no conflicts with the base branch

### Screenshots (If appropriate)
![Screenshot 2024-09-11 233018](https://github.com/user-attachments/assets/df1ed8e5-b122-4fdb-a4c3-adb3f938f1a4)
![Screenshot 2024-09-15 191216](https://github.com/user-attachments/assets/e44f8748-e55a-457f-a144-e717d7e2c074)

![Screenshot 2024-09-11 232936](https://github.com/user-attachments/assets/90b9cc3e-39ac-4c48-8bde-6c1cb39803f7)
