### PR TITLE
#289 filter Invitation statistics based on different time ranges

### DIFF
--- a/src/schema/invitationStatics.schema.ts
+++ b/src/schema/invitationStatics.schema.ts
@@ -5,11 +5,16 @@ const statisticsSchema = gql`
     totalInvitations: Int!
     acceptedInvitationsCount: Int!
     pendingInvitationsCount: Int!
-    getAcceptedInvitationsPercentsCount: Int!
-    getPendingInvitationsPercentsCount: Int!
+    getAcceptedInvitationsPercentsCount: Float!
+    getPendingInvitationsPercentsCount: Float!
   }
   type Query {
-    getInvitationStatistics(orgToken: String!): Statistics!
+    getInvitationStatistics(
+      orgToken: String!
+      startDate: String
+      endDate: String
+      daysRange: Int
+    ): Statistics!
   }
 `
 


### PR DESCRIPTION
### PR Description
Filtering Invitation statistics based on the time range provided

### Description of tasks that were expected to be completed
Display invitation statistics specific to the time intervals or time slot provided by an admin

### Functionality
Get or view invitation statistics in different time ranges

### How has this been tested?
Log in as an admin, go to invitations and execute a query of getInvitationstatistics and provide variables like ending date, start date or even days Range then see the difference in statistics and the  variables change 

### PR Checklist:
- [ ] Get statistics
- [ ] Filter invitation statistics

  