### PR TITLE
#279 Update user's invitation

### DIFF
--- a/src/helpers/generateInvitationToken.helper.ts
+++ b/src/helpers/generateInvitationToken.helper.ts
@@ -1,0 +1,27 @@
+import jwt from 'jsonwebtoken';
+
+const SECRET: string = process.env.SECRET ?? 'test_secret'
+
+export default async function generateInvitationTokenAndLink(
+  email: string,
+  role: string,
+  orgName: string
+): Promise<{ newToken: string; link: string }> {
+
+  const token = jwt.sign(
+    {
+      name: orgName,
+      email,
+      role,
+    },
+    SECRET,
+    { expiresIn: '2d' }
+  );
+
+  const newToken = token.replace(/\./g, '*');
+
+  // Generate the invitation link
+  const link = `${process.env.REGISTER_FRONTEND_URL}/${newToken}`;
+
+  return { newToken, link };
+}

--- a/src/helpers/sendInvitaitonEmail.ts
+++ b/src/helpers/sendInvitaitonEmail.ts
@@ -1,5 +1,6 @@
 import { sendEmail } from '../utils/sendEmail';
 import inviteUserTemplate from '../utils/templates/inviteUserTemplate';
+import updateInvitationTemplate from '../utils/templates/updateInvitationTemplate';
 import { Role } from '../resolvers/invitation.resolvers';
 import  jwt  from 'jsonwebtoken';
 
@@ -12,23 +13,12 @@ interface Payload{
 const SECRET: string = process.env.SECRET ?? 'test_secret'
 export default async function sendInvitationEmail(
   email: string,
-  payLoad:Payload
+  orgName: string,
+  link: string,
+  updateInvitation = false
 ) {
   try {
-    // Create a token for the invitation
-    const token = jwt.sign(
-      {
-        name:payLoad.org.name,
-        email,
-        role:payLoad.role,
-      },
-      SECRET,
-      { expiresIn: '2d' }
-    );
-  
-    const newToken = token.replace(/\./g, '*');
-    const link = `${process.env.REGISTER_FRONTEND_URL}/${newToken}`;
-    const content = inviteUserTemplate(payLoad.org?.name || '', link);
+    const content = updateInvitation ? updateInvitationTemplate(orgName || '', link) : inviteUserTemplate(orgName || '', link);
   
     // Send invitation email
     await sendEmail(

--- a/src/models/invitation.model.ts
+++ b/src/models/invitation.model.ts
@@ -41,6 +41,10 @@ const InvitationSchema = new Schema({
     type:String,
     required:true
   },
+  invitationToken:{
+    type: String,
+    maxlength: 2048,
+  },
   createdAt: {
     type: Date,
     default: Date.now,

--- a/src/resolvers/userResolver.ts
+++ b/src/resolvers/userResolver.ts
@@ -228,9 +228,20 @@ const resolvers: any = {
         .sort({ createdAt: -1 })
         .exec()
 
-      if (invitation) {
+      if (!invitation || invitation.status === 'cancelled') {
+        throw new GraphQLError('Invalid or expired invitation. Please request a new one.');
+      } else{
+        let invitationToken: any = invitation.invitationToken;
+        if (invitationToken){
+          invitationToken = invitationToken.replaceAll('*', '.');
+        }
+
         invitee = invitation.invitees.find((invitee) => invitee.email === email)
+        if(orgToken !== invitationToken){
+          throw new GraphQLError('Invalid or expired invitation token.');
+        }
       }
+      
       const user = await User.create({
         role: role || 'user',
         email: email,
@@ -240,6 +251,11 @@ const resolvers: any = {
       const token = jwt.sign({ userId: user._id, role: user?.role }, SECRET, {
         expiresIn: '2h',
       })
+
+      if(user && invitation){
+        invitation.status = 'accepted'
+        await invitation.save()
+      }
 
       const newProfile = await Profile.create({
         user,

--- a/src/schema/invitation.schema.ts
+++ b/src/schema/invitation.schema.ts
@@ -72,7 +72,7 @@ const invitationSchema = gql`
 
   type Mutation {
     sendInvitation(invitees: [InviteeInput!]!, orgToken: String!): Invitation!
-
+    updateInvitation(invitationId: ID!, orgToken: String!, newEmail: String, newRole: String): Invitation
     uploadInvitationFile(file: Upload!, orgToken: String!): FileData!
     deleteInvitation(invitationId: ID!): DeleteMessage
   }

--- a/src/utils/templates/updateInvitationTemplate.ts
+++ b/src/utils/templates/updateInvitationTemplate.ts
@@ -1,0 +1,43 @@
+export default function updateInvitationTemplate(orgName: string, link: string) {
+    return `
+    <table style="border: 1px solid #ddd; padding: 16px; border-radius: 8px; background-color: #f9f9f9; max-width: 600px; margin: 0 auto; font-family: 'Rubik', sans-serif;">
+          <!-- Icon Container -->
+          <tr>
+              <td style="width: 100%; background-color: #E0E7FF; padding: 16px; text-align: center;">
+                  <table width="100%" border="0" cellpadding="16" cellspacing="0" style="border-radius: 8px 8px 0 0;">
+                      <tr>
+                          <td style="text-align: center;">
+                              <img src="https://res.cloudinary.com/ddf0u9tgz/image/upload/v1724949908/emailLogo_rmmwdi.png" style="width: 200px; height: 200px;" alt="Logo" />
+                              <p style="margin: 10px 0 0; font-size: 18px; font-weight: bold; color: #8667F2;">Invitation Updated</p>
+                          </td>
+                      </tr>
+                  </table>
+              </td>
+          </tr>
+          <!-- Message Container -->
+          <tr>
+              <td style="padding: 16px; color: black; text-align: left;">
+                  <p>Hello,</p>
+                  <p>Your invitation to join <strong>${orgName}</strong> has been updated.</p>
+                  <p>We invite you to review the updated invitation and accept it by clicking the button below:</p>
+                  <!-- Button -->
+                  <table style="width: 100%; text-align: center; margin-top: 20px;">
+                      <tr>
+                          <td>
+                              <a href="${link}" style="text-decoration: none;">
+                                  <button style="font-size: 16px; background-color: #8667F2; font-family: 'Rubik', sans-serif; text-align: center; border: none; border-radius: 3px; padding: 10px 20px; cursor: pointer; color: #fff;">
+                                      Accept Invitation
+                                  </button>
+                              </a>
+                          </td>
+                      </tr>
+                  </table>
+                  <p>If the button doesn't work, copy this link into your browser:</p>
+                  <!-- Link -->
+                  <a href="${link}" style="text-decoration: none; cursor: pointer;">${link}</a>
+              </td>
+          </tr>
+      </table>
+      `
+  }
+  


### PR DESCRIPTION
### PR Description
The admin has the ability to update a user's invitation (email or role). Additionally, once a user registers through an invitation, the invitation's status is updated to "accepted."
### Description of tasks that were expected to be completed

- update the invitation status after a user has registered
- allow admin to update the invitation email
- allow admin to update the invitation role

### Functionality
This functionality allows an admin to update the invitation email or role. Also when a user registers from the invitation, his invitation status updates from pending to accepted
### How has this been tested?
- Clone this repository and navigate to the project directory
```bash
  git clone https://github.com/atlp-rwanda/atlp-pulse-bn.git
  cd atlp-pulse-bn
  git checkout ft-update-invitation
  npm i
  ```
- Ensure that you have set your .env file using .env.example.
  ```
  npm run dev
  ```
- Next, execute the UpdateInvitation mutation in Apollo Sandbox as demonstrated in the screenshot at the bottom. You'll first need to log in to the organization, then log in as an admin user. After that, provide the invitation ID you want to update along with the new role or email details to be updated.
### PR Checklist:
- [x] update the invitation status after a user has registered
- [x] allow admin to update the invitation email
- [x] allow admin to update the invitation role
### Track PR
Trello Link [(#DP-279)](https://github.com/atlp-rwanda/atlp-pulse-bn/issues/279)
### Screenshots (If appropriate)
<img width="1381" alt="Screenshot 2024-09-12 at 14 58 25" src="https://github.com/user-attachments/assets/639b3e0d-305a-460c-9e80-7398f2c6b825">
<img width="1230" alt="Screenshot 2024-09-12 at 15 03 37" src="https://github.com/user-attachments/assets/2678ca08-eec2-40c8-86db-3e8355762829">




  