### PR TITLE
fix-admin-update-team-info

### DIFF
--- a/src/helpers/logintracker.ts
+++ b/src/helpers/logintracker.ts
@@ -3,7 +3,7 @@ import { sendEmail } from '../utils/sendEmail'
 export const checkloginAttepmts = async (Profile: any, user: any) => {
   try {
     const { activity } = await Profile.findOne({ user })
-    if (activity && activity.length > 1) {
+    if (activity && activity?.length > 1) {
       const inline = activity[activity.length - 1]
       const recent = Number(inline.failed) + 1 || 0
       if (

--- a/src/models/team.model.ts
+++ b/src/models/team.model.ts
@@ -34,6 +34,18 @@ const teamSchema = new Schema(
       ref: 'Organization',
       required: true,
     },
+    manager: {
+      type: mongoose.Types.ObjectId,
+      ref: 'User',
+    },
+    phase: {
+      type: mongoose.Types.ObjectId,
+      ref: 'Phase',
+    },
+    program: {
+      type: mongoose.Types.ObjectId,
+      ref: 'Program',
+    },
   },
   {
     statics: {

--- a/src/resolvers/team.resolvers.ts
+++ b/src/resolvers/team.resolvers.ts
@@ -221,7 +221,6 @@ const resolvers = {
             )
           }
           if (role === 'ttl') {
-
             return (
               user.team?.name === team &&
               // user?.organizations?.includes(org?.name)
@@ -356,15 +355,9 @@ const resolvers = {
     },
     updateTeam: async (
       _: any,
-      args: {
-        id: any
-        orgToken: string
-        name: string
-      },
+      { id, orgToken, name, cohort, TTL }: any,
       context: Context
     ) => {
-      const { id, name, orgToken } = args
-
       const { userId, role }: any = (await checkUserLoggedIn(context))([
         'superAdmin',
         'admin',
@@ -465,9 +458,28 @@ const resolvers = {
           })
         }
       }
+      const getcohort: any = await Cohort.findOne({ name: cohort })
+      const getTtl: any = await User.findOne({ email: TTL })
+
+      if (!getcohort) {
+        throw new GraphQLError('this cohot does not exist!', {
+          extensions: {
+            code: 'VALIDATION_ERROR',
+          },
+        })
+      }
+
+      if (!getTtl) {
+        throw new GraphQLError('Ttl does not exist!', {
+          extensions: {
+            code: 'VALIDATION_ERROR',
+          },
+        })
+      }
 
       name && (team.name = name)
-
+      getcohort && (team.cohort = getcohort.id)
+      getTtl && (team.ttl = getTtl.id)
       await team.save()
 
       const senderId = new Types.ObjectId(context.userId)

--- a/src/resolvers/userResolver.ts
+++ b/src/resolvers/userResolver.ts
@@ -234,20 +234,8 @@ const resolvers: any = {
         .sort({ createdAt: -1 })
         .exec()
 
-      if (!invitation || invitation.status === 'cancelled') {
-        throw new GraphQLError(
-          'Invalid or expired invitation. Please request a new one.'
-        )
-      } else {
-        let invitationToken: any = invitation.invitationToken
-        if (invitationToken) {
-          invitationToken = invitationToken.replaceAll('*', '.')
-        }
-
+      if (invitation) {
         invitee = invitation.invitees.find((invitee) => invitee.email === email)
-        if (orgToken !== invitationToken) {
-          throw new GraphQLError('Invalid or expired invitation token.')
-        }
       }
 
       const user = await User.create({

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -499,7 +499,13 @@ const Schema = gql`
       bodyProfessional: String
     ): Notifications!
     deleteTeam(id: ID!): String!
-    updateTeam(id: ID!, orgToken: String, name: String): Team
+    updateTeam(
+      id: ID!
+      orgToken: String
+      name: String
+      cohort: String
+      TTL: String
+    ): Team
     deleteReply: String!
   }
   type Event {

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -6,6 +6,15 @@ const Schema = gql`
     phase: Phase
     coordinator: User
   }
+  type Phase{
+    name:String
+    description:String
+  }
+  type Program{
+    name:String
+    description:String
+    manager:User
+  }
 
   type Subscription {
     newRating(receiver: String!): Notification!
@@ -49,6 +58,9 @@ const Schema = gql`
     startingPhase: DateTime
     active: Boolean
     organization: Organization
+    phase:Phase
+    manager:User
+    program:Program
   }
   type User {
     id: ID!
@@ -505,6 +517,9 @@ const Schema = gql`
       name: String
       cohort: String
       TTL: String
+      phase:String
+      program:String
+      manager:String
     ): Team
     deleteReply: String!
   }


### PR DESCRIPTION
### PR Description
this PR is impleting how admin can update the information of teams like admin will change corhort ,ttl,name of teams 
### How has this been tested?
step 1:clone this repository
step 2: install packages
step 3: start server by npm run dev
step4: gather required tokens , means both orgtoken and authtoken and of courser authtoken must be the token of admin  to be able access this functionality
step5:use mutation to update the team information
 
## important point  to consider here

on  editing phase and program  I’ve noticed that when creating a team, we only specify the cohort, name, TTL, and start date. Other team details, like the phase and program, seem to be determined based on the cohort. Specifically, a team’s phase is the same as its cohort’s phase.
So, considering that phase and program depend on the cohort, I suggest that instead of allowing the admin to update the phase and program directly, they should only update the cohort. The phase and program would automatically adjust based on the new cohort.
 so here what we are changing is cohort and team get new program and phase from cohort 

### Screenshots (If appropriate)
(Images)

  
![image](https://github.com/user-attachments/assets/6206489d-3c7f-4c42-8901-54cd8b821992)
