### PR TITLE
#272 Admin delete user

### DIFF
--- a/src/resolvers/cohort.resolvers.ts
+++ b/src/resolvers/cohort.resolvers.ts
@@ -11,7 +11,7 @@ import { Context } from './../context'
 import { ProgramType } from './program.resolvers'
 import { OrganizationType } from './userResolver'
 import { pushNotification } from '../utils/notification/pushNotification'
-import {  Types } from 'mongoose'
+import { Types } from 'mongoose'
 
 export type CohortType = InstanceType<typeof Cohort>
 
@@ -74,6 +74,7 @@ const resolvers = {
       }
     },
   },
+
   Mutation: {
     addCohort: async (
       _: any,
@@ -142,7 +143,7 @@ const resolvers = {
           endDate &&
           isAfter(new Date(startDate.toString()), new Date(endDate.toString()))
         ) {
-          throw new GraphQLError('End Date can\'t be before Start Date', {
+          throw new GraphQLError("End Date can't be before Start Date", {
             extensions: {
               code: 'VALIDATION_ERROR',
             },
@@ -286,7 +287,7 @@ const resolvers = {
             new Date(endDate)
           ))
       ) {
-        throw new GraphQLError('End Date can\'t be before Start Date', {
+        throw new GraphQLError("End Date can't be before Start Date", {
           extensions: {
             code: 'VALIDATION_ERROR',
           },
@@ -473,8 +474,13 @@ const resolvers = {
         }
       }
 
-      const senderId = new Types.ObjectId(context.userId);
-      cohort.coordinator && pushNotification(new Types.ObjectId(cohort.coordinator.toString()), `Your cohort "${cohort.name}" has been deactivated`, senderId);
+      const senderId = new Types.ObjectId(context.userId)
+      cohort.coordinator &&
+        pushNotification(
+          new Types.ObjectId(cohort.coordinator.toString()),
+          `Your cohort "${cohort.name}" has been deactivated`,
+          senderId
+        )
 
       return Cohort.disactivate(cohort?.id)
     },

--- a/src/resolvers/userResolver.ts
+++ b/src/resolvers/userResolver.ts
@@ -284,6 +284,7 @@ const resolvers: any = {
 
       return { token, user: newUser }
     },
+
     async createProfile(_: any, args: any, context: { userId: any }) {
       if (!context.userId) throw new Error('Unauthorized')
       if (!mongoose.isValidObjectId(context.userId))
@@ -301,6 +302,7 @@ const resolvers: any = {
 
       return profile.toJSON()
     },
+
     async loginUser(
       _: any,
       { loginInput: { email, password, orgToken, activity } }: any
@@ -503,6 +505,25 @@ const resolvers: any = {
           },
         })
       }
+    },
+
+    async deleteUser(_: any, { input }: any, context: { userId: any }) {
+      const requester = await User.findById(context.userId)
+      console.log(input)
+      if (!requester) {
+        throw new Error('Requester does not exist')
+      }
+      if (requester.role !== 'admin' && requester.role !== 'superAdmin') {
+        throw new Error('You do not have permission to delete users')
+      }
+      const userToDelete = await User.findById(input.id)
+      if (!userToDelete) {
+        throw new Error('User to be deleted does not exist')
+      }
+
+      await User.findByIdAndDelete(input.id)
+      await Profile.deleteOne({ user: input.id })
+      return { message: 'User deleted successfully' }
     },
 
     async updateUserRole(_: any, { id, name, orgToken }: any) {
@@ -809,6 +830,7 @@ const resolvers: any = {
 
       return orgExists
     },
+
     async addOrganization(
       _: any,
       { organizationInput: { name, email, description }, action: action }: any,
@@ -993,6 +1015,7 @@ const resolvers: any = {
         )
       return deleteOrg
     },
+
     async forgotPassword(_: any, { email }: any) {
       const userExists: any = await User.findOne({ email })
 
@@ -1018,6 +1041,7 @@ const resolvers: any = {
         throw new Error('Something went wrong!\nCheck your credentials')
       }
     },
+
     async updateEmailNotifications(_: any, { id }: any, context: Context) {
       const user: any = await User.findOne({ _id: id })
       if (!user) {
@@ -1030,6 +1054,7 @@ const resolvers: any = {
       )
       return 'updated successful'
     },
+
     async updatePushNotifications(_: any, { id }: any, context: Context) {
       const user: any = await User.findOne({ _id: id })
       if (!user) {
@@ -1040,6 +1065,7 @@ const resolvers: any = {
       const updatedPushNotifications = user.pushNotifications
       return 'updated successful'
     },
+
     async resetUserPassword(
       _: any,
       { password, confirmPassword, token }: any,

--- a/src/resolvers/userResolver.ts
+++ b/src/resolvers/userResolver.ts
@@ -27,6 +27,7 @@ import { checkloginAttepmts } from '../helpers/logintracker'
 import { Rating } from '../models/ratings'
 import { Invitation } from '../models/invitation.model'
 import isAssigned from '../helpers/isAssignedToProgramOrCohort'
+import { pushNotification } from '../utils/notification/pushNotification'
 const octokit = new Octokit({ auth: `${process.env.GH_TOKEN}` })
 
 const SECRET: string = process.env.SECRET ?? 'test_secret'
@@ -509,7 +510,6 @@ const resolvers: any = {
 
     async deleteUser(_: any, { input }: any, context: { userId: any }) {
       const requester = await User.findById(context.userId)
-      console.log(input)
       if (!requester) {
         throw new Error('Requester does not exist')
       }
@@ -520,7 +520,30 @@ const resolvers: any = {
       if (!userToDelete) {
         throw new Error('User to be deleted does not exist')
       }
-
+      if (userToDelete.role === 'coordinator') {
+        const hasCohort = await Cohort.findOne({ coordinator: input.id })
+        if (hasCohort) {
+          await Cohort.findOneAndReplace(
+            { coordinator: input.id },
+            { coordinator: null }
+          )
+          await pushNotification(
+            context.userId,
+            `You have deleted the coordinator of ${hasCohort.name}, Assign the new coordinator`,
+            context.userId
+          )
+        }
+      } else if (userToDelete.role === 'ttl') {
+        const hasTeam = await Team.findOne({ ttl: input.id })
+        if (hasTeam) {
+          await Team.findOneAndReplace({ ttl: input.id }, { ttl: null })
+          await pushNotification(
+            context.userId,
+            `You have deleted the TTL of  ${Team.name}, Assign the new TTL`,
+            context.userId
+          )
+        }
+      }
       await User.findByIdAndDelete(input.id)
       await Profile.deleteOne({ user: input.id })
       return { message: 'User deleted successfully' }

--- a/src/schema/coordinator.schema.ts
+++ b/src/schema/coordinator.schema.ts
@@ -11,6 +11,7 @@ const Schema = gql`
   type Message {
     message: String
   }
+
   type Mutation {
     addMemberToTeam(
       teamName: String!

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -90,6 +90,19 @@ const Schema = gql`
   input OrgInput {
     name: String
   }
+
+  input DeleteUserInput {
+    id: ID!
+  }
+
+  type DeleteUserPayload {
+    message: String!
+  }
+
+  type Mutation {
+    deleteUser(input: DeleteUserInput!): DeleteUserPayload!
+  }
+
   type Profile {
     id: ID!
     user: User!


### PR DESCRIPTION
### PR Description
This PR Allows the admins, the super admin to delete the user.

### Description of tasks to be completed

- [x] Admin should be able to delete the user
- [x] We should notify the admin when he deletes the TTL with the Team
- [x] We should notify the admin when he deletes the Coordinator
- [x] We should make the TTL and coordinators null when deleted

### How should it be tested

1. Clone this repo
2. checkout to the branch: `git checkout ft-deleteuser-272` 
3. install the packages by `npm install`
4. make sure the set the .env variales as described in _.env.example_
5. run seed by `npm run seed`
6. After, use the graphql,apollo server to sign in as the admin

### PR Checklist:

- [x]  My code follows the style guidelines of this project.
- [x]  I have performed a self-review of my code.
- [ ]  My code generates no warnings.
- [x]  I have commented my code, particularly in hard-to-understand areas.
- [x]  My test coverage meets the set test coverage threshold.
- [ ]  There are no vulnerabilities.
- [x]  There are no conflicts with the base branch.
