### PR TITLE
#274 ft trainees login without cohort 

### DIFF
--- a/src/resolvers/userResolver.ts
+++ b/src/resolvers/userResolver.ts
@@ -341,7 +341,7 @@ const resolvers: any = {
           { $push: { activity: { $each: [newActivity] } } }
         )
         if (
-          user?.role === 'trainee' ||
+          user?.role === 'trainee' &&
           user?.organizations?.includes(org?.name)
         ) {
           const token = jwt.sign(


### PR DESCRIPTION
**PR Description**
This pull request ensures that a trainee can only log in once they have been assigned to a cohort. It addresses the issue where new trainees were able to log in without a cohort assignment, which contradicts the intended functionality.

**Description of tasks that were expected to be completed**
Ensure that trainees without a cohort assignment are restricted from logging in.
Modify the login authentication flow to include cohort assignment validation.
Update any related error messages or user notifications to reflect the cohort requirement.
Functionality
This implementation works by checking if the trainee is assigned to a cohort before allowing them to log in. If the trainee is not assigned to a cohort, they are prevented from accessing the system, and an appropriate error message is displayed.

**How has this been tested?**
Unit Testing: I created unit tests to validate that trainees without a cohort cannot log in and that those assigned to a cohort are granted access.
Manual Testing: I manually tested the login process by creating a trainee account with and without a cohort assignment, confirming that only trainees with a cohort can log in.
Steps to reproduce:

Create a trainee account without assigning a cohort.
Attempt to log in using the trainee account; the system should prevent access.
Assign a cohort to the trainee account.
Attempt to log in again; the system should now grant access.

**PR Checklist:**
 Task 1: Modify authentication logic to include cohort assignment validation.
 Task 2: Add appropriate error handling for trainees without a cohort.
 Task 3: Update tests to ensure correct functionality.
 Task 4: Perform manual testing to confirm that the cohort assignment requirement is respected.
 
### Screenshots (If appropriate)
https://www.loom.com/share/50482176c43f436a8dbb10c8e2a9ee40
  