### PR TITLE
Fix allowing both ttl and coordinator rating trainee

### DIFF
--- a/src/helpers/isAssignedToProgramOrCohort.ts
+++ b/src/helpers/isAssignedToProgramOrCohort.ts
@@ -1,41 +1,41 @@
-import Cohort from "../models/cohort.model";
-import { Organization } from "../models/organization.model";
-import Program from "../models/program.model";
+import Cohort from '../models/cohort.model'
+import { Organization } from '../models/organization.model'
+import Program from '../models/program.model'
 
-export default async function isAssgined(organName:String){
-    const programs:any = await Program.find().populate({
-        path: 'organization',
-        model: Organization,
-        strictPopulate: false,
-      });
-      const cohorts:any = await Cohort.find().populate({
-        path: 'program',
-        model: Program,
-        strictPopulate: false,
-        populate: {
-          path: 'organization',
-          model: Organization,
-          strictPopulate: false,
-        },
-      });
-      let isAssignedToProgramOrCohort = false;
-    
-      // Check if the user is assigned to any program associated with the organization
-      for (const element of programs) {
-        if (element.organization?.name === organName) {
-          isAssignedToProgramOrCohort = true;
-          break;
-        }
+export default async function isAssgined(organName: string) {
+  const programs: any = await Program.find().populate({
+    path: 'organization',
+    model: Organization,
+    strictPopulate: false,
+  })
+  const cohorts: any = await Cohort.find().populate({
+    path: 'program',
+    model: Program,
+    strictPopulate: false,
+    populate: {
+      path: 'organization',
+      model: Organization,
+      strictPopulate: false,
+    },
+  })
+  let isAssignedToProgramOrCohort = false
+
+  // Check if the user is assigned to any program associated with the organization
+  for (const element of programs) {
+    if (element.organization?.name === organName) {
+      isAssignedToProgramOrCohort = true
+      break
+    }
+  }
+
+  // Check if the user is assigned to any cohort associated with the organization
+  if (!isAssignedToProgramOrCohort) {
+    for (const cohort of cohorts) {
+      if (cohort.program.organization?.name === organName) {
+        isAssignedToProgramOrCohort = true
+        break
       }
-    
-      // Check if the user is assigned to any cohort associated with the organization
-      if (!isAssignedToProgramOrCohort) {
-        for (const cohort of cohorts) {
-          if (cohort.program.organization?.name === organName) {
-            isAssignedToProgramOrCohort = true;
-            break;
-          }
-        }
-      }
-    return isAssignedToProgramOrCohort;
+    }
+  }
+  return isAssignedToProgramOrCohort
 }

--- a/src/resolvers/ratingsResolvers.ts
+++ b/src/resolvers/ratingsResolvers.ts
@@ -6,7 +6,11 @@ import { Context } from './../context'
 import Cohort from '../models/cohort.model'
 import { checkUserLoggedIn } from '../helpers/user.helpers'
 import { Notification } from '../models/notification.model'
-import { authenticated, validateRole } from '../utils/validate-role'
+import {
+  authenticated,
+  validateRole,
+  validateTtlOrCoordinator,
+} from '../utils/validate-role'
 import { checkLoggedInOrganization } from '../helpers/organization.helper'
 import generalTemplate from '../utils/templates/generalTemplate'
 import { PubSub, withFilter } from 'graphql-subscriptions'
@@ -174,7 +178,7 @@ const ratingResolvers: any = {
   },
   Mutation: {
     addRatings: authenticated(
-      validateRole('ttl')(
+      validateTtlOrCoordinator(['coordinator', 'ttl'])(
         async (
           root,
           {
@@ -297,7 +301,7 @@ const ratingResolvers: any = {
       return 'The rating table has been deleted successfully'
     },
     updateRating: authenticated(
-      validateRole('ttl')(
+      validateTtlOrCoordinator(['coordinator', 'ttl'])(
         async (
           root,
           {

--- a/src/resolvers/userResolver.ts
+++ b/src/resolvers/userResolver.ts
@@ -345,20 +345,21 @@ const resolvers: any = {
           user?.role === 'trainee' &&
           user?.organizations?.includes(org?.name)
         ) {
-         
           if (await isAssgined(org?.name)) {
             const token = jwt.sign(
               { userId: user._id, role: user._doc?.role || 'user' },
               SECRET,
               { expiresIn: '2h' }
-            );
+            )
             const data = {
               token: token,
               user: user.toJSON(),
-            };
-            return data;
+            }
+            return data
           } else {
-            throw new Error('You are not assigned to any valid program or cohort in this organization.');
+            throw new Error(
+              'You are not assigned to any valid program or cohort in this organization.'
+            )
           }
         }
 

--- a/src/utils/validate-role.ts
+++ b/src/utils/validate-role.ts
@@ -1,20 +1,32 @@
 export const authenticated =
   (next: (arg0: any, arg1: any, arg2: any, arg3: any) => any) =>
-    (root: any, args: any, context: { userId: any }, info: any) => {
-      if (!context.userId) {
-        throw new Error('Unauthenticated!');
-      }
+  (root: any, args: any, context: { userId: any }, info: any) => {
+    if (!context.userId) {
+      throw new Error('Unauthenticated!')
+    }
 
-      return next(root, args, context, info);
-    };
+    return next(root, args, context, info)
+  }
 
 export const validateRole =
   (role: any) =>
-    (next: (arg0: any, arg1: any, arg2: any, arg3: any) => any) =>
-      (root: any, args: any, context: { role: { role: any } }, info: any) => {
-        if (context.role !== role) {
-          throw new Error('only authorized users can perform operation!');
-        }
+  (next: (arg0: any, arg1: any, arg2: any, arg3: any) => any) =>
+  (root: any, args: any, context: { role: { role: any } }, info: any) => {
+    if (context.role !== role) {
+      throw new Error('only authorized users can perform operation!')
+    }
 
-        return next(root, args, context, info);
-      };
+    return next(root, args, context, info)
+  }
+
+export const validateTtlOrCoordinator =
+  (roles: string[]) =>
+  (next: (arg0: any, arg1: any, arg2: any, arg3: any) => any) =>
+  (root: any, args: any, context: { role: string }, info: any) => {
+    // Check if user's role is in the allowed roles
+    if (!roles.includes(context.role)) {
+      throw new Error('Only authorized users can perform this operation!')
+    }
+
+    return next(root, args, context, info)
+  }


### PR DESCRIPTION
**PR Description**
The app should allow TTLs to rate not just managers.

**How has this been tested?**
Clone the project `https://github.com/atlp-rwanda/atlp-pulse-bn.git` switch to `fx-allow-ttl-to-rate` branch.
for front end clone this `https://github.com/atlp-rwanda/atlp-pulse-fn.git` switch to `fx-allow-ttl-to-rate` branch

include all env variables for both backend and front end then install all dependencies `npm install` and run with `npm run dev`

