### PR TITLE
#469 Fix on Getting Cancel Invitation Statistics

### DIFF
--- a/src/resolvers/invitation.resolvers.ts
+++ b/src/resolvers/invitation.resolvers.ts
@@ -385,19 +385,28 @@ const invitationResolvers: IResolvers = {
         (invitation) => invitation.status === 'pending'
       ).length
 
+      const cancelledInvitationsCount = invitations.filter(
+        (invitation) => invitation.status === 'cancelled'
+      ).length
+
       const getAcceptedInvitationsPercentsCount = totalInvitations
         ? Math.round((acceptedInvitationsCount / totalInvitations) * 100)
         : 0
       const getPendingInvitationsPercentsCount = totalInvitations
         ? Math.round((pendingInvitationsCount / totalInvitations) * 100)
         : 0
+      const getCancelledInvitationsPercentsCount = totalInvitations
+        ? Math.round((cancelledInvitationsCount / totalInvitations) * 100)
+        : 0
 
       return {
         totalInvitations,
         acceptedInvitationsCount,
         pendingInvitationsCount,
+        cancelledInvitationsCount,
         getAcceptedInvitationsPercentsCount,
         getPendingInvitationsPercentsCount,
+        getCancelledInvitationsPercentsCount,
       }
     },
   },


### PR DESCRIPTION
### PR Description
this PR contains new feature of cancelling an invitatation by Admin
### Description of tasks that were expected to be completed
- [x] branch creation.
- [x] add `cancelled ` status in model
- [x] create cancelInvitation function and it's mutation
- [x] after cancelling invitation, an email is sent
- [x] add cancelInvitation in invitation statistics
### Functionality
- clone the repository
- `git checkout ft-cancel-invite-469`
- `npm i` and `npm run dev`
-  test invitation mutations and querries
### How has this been tested?
Tested on apolloGraphql after running `npm run dev`, first log an organisation in, then an admin, and finallt test the mutation to cancel invitation and querries to get all invitation, and statistics
### PR Checklist:
 -  [x] My code follows the style guidelines of this project
 -  [x] I have performed a self-review of my code
 -  [x]  I have commented my code, particularly in hard-to-understand areas
 -  [x] My code generate no warnings
 -  [x] My test coverage meet the set test coverage threshold
 -  [x] There are no vulnerabilities
 -  [x] There are no conflicts with the base branch

### Screenshots (If appropriate)
![Screenshot 2024-09-11 233018](https://github.com/user-attachments/assets/df1ed8e5-b122-4fdb-a4c3-adb3f938f1a4)
![Screenshot 2024-09-15 191216](https://github.com/user-attachments/assets/e44f8748-e55a-457f-a144-e717d7e2c074)

![Screenshot 2024-09-11 232936](https://github.com/user-attachments/assets/90b9cc3e-39ac-4c48-8bde-6c1cb39803f7)
