### PR TITLE
Fix invitation filter based on time range.

### DIFF
--- a/src/models/invitation.model.ts
+++ b/src/models/invitation.model.ts
@@ -37,6 +37,10 @@ const InvitationSchema = new Schema({
       },
     },
   ],
+  orgName: {
+    type: String,
+    required: true,
+  },
   orgToken: {
     type: String,
     required: true,

--- a/src/resolvers/invitation.resolvers.ts
+++ b/src/resolvers/invitation.resolvers.ts
@@ -362,54 +362,6 @@ const invitationResolvers: IResolvers = {
       return { message: 'Invitation deleted successfully ' }
     },
   },
-  Query: {
-    getInvitationStatistics: async (_: any, __: any, context: any) => {
-      const { userId } = (await checkUserLoggedIn(context))(['admin'])
-      if (!userId) {
-        throw new GraphQLError('User is not logged in', {
-          extensions: {
-            code: 'UNAUTHENTICATED',
-          },
-        })
-      }
-
-      const invitations = await Invitation.find({
-        inviterId: userId.toString(),
-      })
-
-      const totalInvitations = invitations.length
-      const acceptedInvitationsCount = invitations.filter(
-        (invitation) => invitation.status === 'accepted'
-      ).length
-      const pendingInvitationsCount = invitations.filter(
-        (invitation) => invitation.status === 'pending'
-      ).length
-
-      const cancelledInvitationsCount = invitations.filter(
-        (invitation) => invitation.status === 'cancelled'
-      ).length
-
-      const getAcceptedInvitationsPercentsCount = totalInvitations
-        ? Math.round((acceptedInvitationsCount / totalInvitations) * 100)
-        : 0
-      const getPendingInvitationsPercentsCount = totalInvitations
-        ? Math.round((pendingInvitationsCount / totalInvitations) * 100)
-        : 0
-      const getCancelledInvitationsPercentsCount = totalInvitations
-        ? Math.round((cancelledInvitationsCount / totalInvitations) * 100)
-        : 0
-
-      return {
-        totalInvitations,
-        acceptedInvitationsCount,
-        pendingInvitationsCount,
-        cancelledInvitationsCount,
-        getAcceptedInvitationsPercentsCount,
-        getPendingInvitationsPercentsCount,
-        getCancelledInvitationsPercentsCount,
-      }
-    },
-  },
 }
 
 export default invitationResolvers

--- a/src/resolvers/invitation.resolvers.ts
+++ b/src/resolvers/invitation.resolvers.ts
@@ -32,7 +32,8 @@ const invitationResolvers: IResolvers = {
       {
         invitees,
         orgToken,
-      }: { invitees: { email: string; role: string }[]; orgToken: string },
+        orgName,
+      }: { invitees: { email: string; role: string }[]; orgName: string; orgToken: string },
       context
     ) => {
       try {
@@ -67,6 +68,7 @@ const invitationResolvers: IResolvers = {
               role: invitee.role,
             })),
             orgToken,
+            orgName,
           })
 
           const { newToken, link } = await generateInvitationTokenAndLink(
@@ -164,7 +166,7 @@ const invitationResolvers: IResolvers = {
 
     async uploadInvitationFile(
       _: any,
-      { file, orgToken }: { file: any; orgToken: string },
+      { file,orgName, orgToken }: { file: any;orgName: string, orgToken: string },
       context: any
     ) {
       const { userId } = (await checkUserLoggedIn(context))(['admin'])
@@ -211,6 +213,7 @@ const invitationResolvers: IResolvers = {
           const newInvitation = new Invitation({
             inviterId: userId.toString(),
             invitees: [{ email, role }],
+            orgName,
             orgToken,
           })
 

--- a/src/schema/invitation.schema.ts
+++ b/src/schema/invitation.schema.ts
@@ -28,6 +28,7 @@ const invitationSchema = gql`
     inviterId: String!
     status: String!
     invitees: [Invitee!]!
+    orgName: String!
     orgToken: String!
     createdAt: String!
   }
@@ -44,6 +45,7 @@ const invitationSchema = gql`
 
   type Query {
     getInvitations(
+      orgToken: String,
       query: String!
       limit: Int
       offset: Int
@@ -51,7 +53,7 @@ const invitationSchema = gql`
   }
 
   type Query {
-    getAllInvitations(limit: Int, offset: Int): PaginatedInvitations!
+    getAllInvitations(orgToken: String!,limit: Int, offset: Int): PaginatedInvitations!
   }
 
     type Query {
@@ -76,9 +78,9 @@ const invitationSchema = gql`
   }
 
   type Mutation {
-    sendInvitation(invitees: [InviteeInput!]!, orgToken: String!): Invitation!
+    sendInvitation(invitees: [InviteeInput!]!,orgName: String!, orgToken: String!): Invitation!
     updateInvitation(invitationId: ID!, orgToken: String!, newEmail: String, newRole: String): Invitation
-    uploadInvitationFile(file: Upload!, orgToken: String!): FileData!
+    uploadInvitationFile(file: Upload!,orgName: String!, orgToken: String!): FileData!
     deleteInvitation(invitationId: ID!): DeleteMessage
     cancelInvitation(orgToken: String!, id: ID!): Invitation!
   }


### PR DESCRIPTION
### PR Description
-Removing a duplicate querry to retrieve or to get invitation statistics
### How has this been tested?
Clone this[ repostory](https://github.com/atlp-rwanda/atlp-pulse-bn)  cd into it, after that checkout the branch _fix-invitation-timerange-filiter_  then open it in your editor.
Run: 
- npm install : to install dependencies 
- npm run dev : to start the server 

or test it with this deployed [link](https://devpulse-backend-pr-313.onrender.com/)  Login as admin with the following credentials; eamil: devpulse@proton.me and password:    Test@12345, after logging in navigate to invitation page. Start playing with it by selecting diffellent timerages.

### PR Checklist:
- [ ] Task 1.
- [ ] Task 2.
- [ ] Task 3.
- [ ] Task n.
### Track PR
Trello Link (#DP-?)
### Screenshots (If appropriate)
(Images)
  