### PR TITLE
fx(filtering): Fixing filtering on table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ dist
 ci-pipeline.yml
 
 .DS_Store
+yarn.lock

--- a/src/resolvers/invitationStatics.resolvers.ts
+++ b/src/resolvers/invitationStatics.resolvers.ts
@@ -30,7 +30,7 @@ const StatisticsResolvers = {
       const organization = org.name.toLocaleLowerCase();
       try {
         const query: any = {
-            'orgName': organization ,
+          'orgName': organization ,
         };
 
         if (daysRange) {
@@ -45,9 +45,23 @@ const StatisticsResolvers = {
         }
 
         if (startDate || endDate) {
-          query.createdAt = query.createdAt || {}
-          if (startDate) query.createdAt.$gte = new Date(startDate)
-          if (endDate) query.createdAt.$lte = new Date(endDate)
+          query.createdAt = {};
+
+          if (startDate) query.createdAt.$gte = new Date(startDate);
+          if (endDate) {
+            const endOfDay = new Date(endDate);
+            endOfDay.setHours(23, 59, 59, 999); 
+            query.createdAt.$lte = endOfDay;
+          }
+        } if (daysRange) {
+          const today = new Date()
+          const rangeStartDate = new Date(today)
+          rangeStartDate.setDate(today.getDate() - daysRange)
+
+          query.createdAt = {
+            $gte: rangeStartDate,
+            $lte: today,
+          }
         }
         const invitations = await Invitation.find(query);
         if (!invitations.length) {

--- a/src/schema/invitation.schema.ts
+++ b/src/schema/invitation.schema.ts
@@ -57,7 +57,7 @@ const invitationSchema = gql`
   }
 
     type Query {
-    filterInvitations(limit: Int, offset: Int, role: String, status: String): PaginatedInvitations!
+    filterInvitations(limit: Int, offset: Int, role: String, status: String, orgToken: String!): PaginatedInvitations!
   }
 
   type InvitationResult {


### PR DESCRIPTION
### PR Description
Fixes filtering table: Admin can filter invitations he/she has invited
### Description of tasks that were expected to be completed
1. Fixed verification of organization token to filter information based on the token
### How has this been tested?
1. Clone the repository using `git clone`
Navigate to the branch using `git checkout fx-invitation-filter`
Run `npm run dev` in the terminal

### Screenshots (If appropriate)

  
![a1](https://github.com/user-attachments/assets/677fe1ef-0266-4b0a-8e88-947847e4e87f)
![a2](https://github.com/user-attachments/assets/10992d62-26b3-4930-90ba-98d03d9587f5)
