### PR TITLE
Remove logging token

### DIFF
--- a/src/utils/logGraphQLRequests.ts
+++ b/src/utils/logGraphQLRequests.ts
@@ -1,17 +1,10 @@
-import logger from './logger.utils'
-
 const logGraphQLRequests = {
   // Fires whenever a GraphQL request is received from a client.
   async requestDidStart(requestContext: any) {
     const noNewlinesQuery: string = requestContext.request.query
       .replace(/\n/g, '')
       .replace(/\s{2,}/g, ' ')
-    logger.debug(
-      'Request Query:\n' +
-        noNewlinesQuery +
-        '\n Request Variables: \n ' +
-        JSON.stringify(requestContext.request.variables)
-    )
   },
 }
+
 export default logGraphQLRequests


### PR DESCRIPTION
## **PR Description**

 This PR removes the logging of sensitive information, specifically the orgToken from GraphQL request logs to improve data security.

## **Description of tasks that were expected to be completed**

- [x] Remove sensitive information from GraphQL request logs.
- [x] Implement logic to create a redacted copy of request variables.
- [x] Test  the log to  ensure that no sensitive information is exposed.

## **How has been this tested**

- Clone the repository.
- Checkout to `ft-remove-loggingToken` branch.
- Make sure all environment variables are configured according to the env.example file.
- Install the dependencies using `npm install`, then run `npm run` dev to verify that the application starts successfully.
- After logging in connected with the frontend login inputs include email, password and OrgToken are not going to be exposed.

## **Screenshots**

![Screenshot (31)](https://github.com/user-attachments/assets/a1e1e810-68cd-450a-91ef-70aedc63f753)

 