### PR TITLE
admin should be able to resend pending invitations

### DIFF
--- a/src/resolvers/invitation.resolvers.ts
+++ b/src/resolvers/invitation.resolvers.ts
@@ -364,6 +364,65 @@ const invitationResolvers: IResolvers = {
       await Invitation.findByIdAndDelete(invitationId)
       return { message: 'Invitation deleted successfully ' }
     },
+
+    resendInvitation:async(_:any,{invitationId,orgToken}:{invitationId:string,orgToken:string},context:any)=>{
+
+      try {
+        const {userId}= (await checkUserLoggedIn(context))(['admin']);
+        if(!userId){
+          throw new GraphQLError('User not logged In',{
+            extensions:{
+              code:'UNAUTHENTICATED'
+            }
+          })
+        }
+        const org=await checkLoggedInOrganization(orgToken);
+        if(!org){
+          throw new GraphQLError('Organization not logged In',{
+            extensions:{
+              code:'UNAUTHENTICATED'
+            }
+          })
+        }
+
+        const invitation= await Invitation.findOne({_id:invitationId,status:'pending',orgName:org.name.toLocaleLowerCase()});
+  
+
+        if(!invitation){
+           throw new GraphQLError('Invitation with the given id does not exists',{
+            extensions:{
+              code:'INVALID_INPUT'
+            }
+           })
+        }
+        const{invitees,orgName}=invitation;
+
+        for( let invitee of invitees){
+          const {newToken,link}=  await generateInvitationTokenAndLink(invitee?.email as string, invitee.role,orgName);
+          invitation.createdAt=new Date();
+          invitation.invitationToken=newToken;
+          await sendInvitationEmail(invitee?.email as string, org.name, link);
+          await  invitation.save();
+        }
+       
+
+        return {
+          success:true,
+          message:"Invitation was resent successfully"
+        }
+        
+      } catch (error:any) {
+
+        throw new GraphQLError(error.message,{
+          extensions:{
+            code:'INTERNAL_SERVER_ERROR'
+          }
+        })
+
+        
+      }
+
+    }
   },
 }
 

--- a/src/schema/invitation.schema.ts
+++ b/src/schema/invitation.schema.ts
@@ -76,6 +76,10 @@ const invitationSchema = gql`
   type DeleteMessage {
     message: String!
   }
+    type InvitationResendResponse{
+    success:Boolean!
+    message:String!
+    }
 
   type Mutation {
     sendInvitation(invitees: [InviteeInput!]!,orgName: String!, orgToken: String!): Invitation!
@@ -83,6 +87,7 @@ const invitationSchema = gql`
     uploadInvitationFile(file: Upload!,orgName: String!, orgToken: String!): FileData!
     deleteInvitation(invitationId: ID!): DeleteMessage
     cancelInvitation(orgToken: String!, id: ID!): Invitation!
+    resendInvitation(orgToken:String!,invitationId:ID!):InvitationResendResponse!
   }
 `;
 


### PR DESCRIPTION
### PR Description
This pr  Adds a feature to  resend invitations that have been Pending
### Description of tasks that were expected to be completed
 As an admin, should be able to resend  pending invitations  in his/her organization . 
### Functionality
In case  there is invitations that have pending status , an admin may need to resend them, that's when the feature comes in, it is applicable  only to invitations in pending status
### How has this been tested?
Clone [this ](https://github.com/atlp-rwanda/atlp-pulse-bn) repo , cd into it, checkout the branch _ft-resend-invitation_  then run the follwoing commands :
- npm install : to install dependencies 
- npm run dev to start the server;
Or you can test this feature by using the deployed link https://metron-devpulse-git-ft-resend-invitation-metron.vercel.app/  

Login in as admin by using the following credetials  Organization:Andela, email:[devpulse@proton.me], password:Test@12345. Try to resend pending invitations.
 
### Track PR
Trello Link (#472)

  