### PR TITLE
Fixing fetching github activity

### DIFF
--- a/src/resolvers/userResolver.ts
+++ b/src/resolvers/userResolver.ts
@@ -28,7 +28,7 @@ import organizationRejectedTemplate from '../utils/templates/organizationRejecte
 import registrationRequest from '../utils/templates/registrationRequestTemplate'
 import { EmailPattern } from '../utils/validation.utils'
 import { Context } from './../context'
-const octokit = new Octokit({ auth: `${process.env.GH_TOKEN}` })
+const octokit = new Octokit({ auth: `${process.env.Org_Repo_Access}` })
 
 const SECRET: string = process.env.SECRET ?? 'test_secret'
 export type OrganizationType = InstanceType<typeof Organization>


### PR DESCRIPTION
### PR Description
This pull request resolves the issue that was raised about viewing detailed info of trainees on the admin dashboard
### Description of tasks that were expected to be completed
Fetch github activity of trainees
### Functionality
The admin will be able to fetch github activity
### How has this been tested?
In Apollo studio log in an admin user with email: "[devpulse@proton.me](mailto:devpulse@proton.me)" and password: "Test@12345".run GitHubActivity query by specifying organisation name and github username
### PR Checklist:
- [x] #348
### Track PR
Trello Link (#DP-?)
### Screenshots (If appropriate)
(Images)
  