### PR TITLE
fix: can't read undefined of organization while creating new organization

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -49,7 +49,10 @@ export const context = async ({ req }: { req: Request }): Promise<Context> => {
   if (
     !token &&
     !req.body.variables.organisationInput &&
-    !req.body.variables.loginInput
+    !req.body.variables.organizationInput &&
+    !req.body.variables.loginInput &&
+    !req.body.variables.orgToken &&
+    !req.body.variables.orgInput
   ) {
     return { clientIpAdress }
   } else {

--- a/src/resolvers/team.resolvers.ts
+++ b/src/resolvers/team.resolvers.ts
@@ -539,7 +539,7 @@ const resolvers = {
       const prevTeamName = team.name
       const teamCohort = team?.cohort
       const cohortProgram = team?.cohort?.program as ProgramType
-      const cohortOrg = cohortProgram.organization as OrganizationType
+      const cohortOrg = cohortProgram?.organization as OrganizationType
       const org = await checkLoggedInOrganization(orgToken)
 
       if (!team) {
@@ -564,8 +564,10 @@ const resolvers = {
 
       if (role !== RoleOfUser.SUPER_ADMIN) {
         const org = await checkLoggedInOrganization(orgToken)
-
-        if (cohortOrg.id.toString() !== org.id.toString()) {
+        console.log('>>>>>>>>>>>>>')
+        console.log(cohortOrg)
+        console.log('>>>>>>>>>>>>>')
+        if (cohortOrg?.id.toString() !== org.id.toString()) {
           throw new GraphQLError(
             `Team with id "${team?.id}" doesn't exist in this organization`,
             {


### PR DESCRIPTION
## fix: can't read undefined of organization while creating new organization
### PR Description
Please include a brief description of the pull request you want to raise.
### Description of tasks that were expected to be completed
- I added ? before organization in team resolver while getting teams 
### Functionality
- navigate to create team menu. and you won't find any warning or error toast message that tasks about it.
### How has this been tested?
i created new team to make sure that before I select new 
### PR Checklist:
- [ ] ? is added to make sure application won't crash if the organization is not available

  