### PR TITLE
#579 Admin should be able to login after signup

### DIFF
--- a/src/resolvers/userResolver.ts
+++ b/src/resolvers/userResolver.ts
@@ -397,14 +397,18 @@ const resolvers: any = {
           admin: user.id,
         })
 
-        if (user?.role === RoleOfUser.ADMIN && organization) {
-          const token = generateToken(user._id, user._doc?.role || 'user')
-          const data = {
-            token: token,
-            user: user.toJSON(),
-          }
-          return data
-        } else if (user?.role === RoleOfUser.MANAGER) {
+        if (user?.role === RoleOfUser.ADMIN) {
+      if (user?.organizations?.includes(org?.name)) {
+        const token = generateToken(user._id, user._doc?.role || 'user');
+        const data = {
+          token: token,
+          user: user.toJSON(),
+        };
+        return data;
+      } else {
+        throw new Error('You do not have access to this organization.');
+      }
+    } else if (user?.role === RoleOfUser.MANAGER) {
           const program: any = await Program.find({
             manager: user.id,
           }).populate({


### PR DESCRIPTION
### PR Description
This PR includes a fix of how admin can be able to login after signup in his/her respective organisation without any hindrance
### Description of tasks that were expected to be completed

1. Admin is only able to login in an organisation he/she belongs to.
2. After signup admin is able to login without being requested to be added to program or cohort

### How has this been tested?

1. Clone your repository using `git clone`

- Run the server `npm run dev`

- Test it either on front end or using apollo graphql server

3. Use this [this](https://devpulse-backend-pr-362.onrender.com) link for testing :

- Login using email:devpulse@proton.me , password :Test@12345,

- Create a user with admin user role

- signup that user 

- Login with the credentials you have already signed up

 
### PR Checklist:
- [ ] Task 1.
- [ ] Task 2.
- [ ] Task 3.
- [ ] Task n.
### Track PR
Trello Link (#579)
### Screenshots (If appropriate)
![Screenshot 2024-10-17 103227](https://github.com/user-attachments/assets/2c765b7f-9deb-4c5d-bf07-39b52dddac6a)
![Screenshot 2024-10-17 103244](https://github.com/user-attachments/assets/2f9f4bde-dc04-4484-beeb-5c9669a012e6)
![Screenshot 2024-10-17 103417](https://github.com/user-attachments/assets/eb68d3f1-b7e6-4a3c-8782-209fe2c2b797)
![Screenshot 2024-10-17 103432](https://github.com/user-attachments/assets/6d4d7267-e310-4362-a658-28c8583a9a58)
![Screenshot 2024-10-17 103454](https://github.com/user-attachments/assets/aa7a7425-e91e-483c-9aa9-7889e42c2543)
![Screenshot 2024-10-17 103505](https://github.com/user-attachments/assets/51b50f7d-d3b1-4a1e-b491-b4e6051efc27)

  