### PR TITLE
#581 sort invitations

### DIFF
--- a/src/resolvers/TableViewInvitationResolver.ts
+++ b/src/resolvers/TableViewInvitationResolver.ts
@@ -1,180 +1,142 @@
 /* eslint-disable indent */
-import { Invitation } from '../models/invitation.model'
-import { ApolloError } from 'apollo-server'
-import { GraphQLError } from 'graphql'
-import { checkUserLoggedIn } from '../helpers/user.helpers'
-import logger from '../utils/logger.utils'
-import { User } from '../models/user'
-import { checkLoggedInOrganization } from '../helpers/organization.helper'
+import { Invitation } from '../models/invitation.model';
+import { ApolloError } from 'apollo-server';
+import { GraphQLError } from 'graphql';
+import { checkUserLoggedIn } from '../helpers/user.helpers';
+import logger from '../utils/logger.utils';
+import { User } from '../models/user';
+import { checkLoggedInOrganization } from '../helpers/organization.helper';
 
 const TableViewInvitationResolver = {
   Query: {
     async getInvitations(
       parent: any,
-      args: { query: string; limit: number; offset: number ;orgToken: string}
+      args: { query: string; limit: number; offset: number; orgToken: string }
     ) {
       try {
-        const { query,orgToken } = args;
+        const { query, orgToken } = args;
         const limit = args.limit ?? 3;
         const offset = args.offset ?? 0;
 
-        if (!query) throw new GraphQLError('No query provided')
+        if (!query) throw new GraphQLError('No query provided');
         if (!orgToken) throw new GraphQLError('No organization token provided');
-          const org = (await checkLoggedInOrganization(orgToken)).name.toLocaleLowerCase();
-          const searchCriteria = {
-            $and: [
-              { orgName: org }, 
-              {
-                $or: [
-                  { 'invitees.email': { $regex: query, $options: 'i' } },
-                  { 'invitees.role': { $regex: query, $options: 'i' } },
-                  { status: { $regex: query, $options: 'i' } },
-                ],
-              },
-            ],
-          };
+
+        const org = (await checkLoggedInOrganization(orgToken)).name.toLocaleLowerCase();
+
+        const searchCriteria = {
+          $and: [
+            { orgName: org },
+            {
+              $or: [
+                { 'invitees.email': { $regex: query, $options: 'i' } },
+                { 'invitees.role': { $regex: query, $options: 'i' } },
+                { status: { $regex: query, $options: 'i' } },
+              ],
+            },
+          ],
+        };
 
         const totalInvitations = await Invitation.countDocuments(searchCriteria);
 
         const invitations = await Invitation.find(searchCriteria)
           .skip(offset)
           .limit(limit)
+          .sort({ createdAt: -1 });
 
         return {
           invitations,
           totalInvitations,
-        }
+        };
       } catch (error) {
-        const { message } = error as { message: any }
+        const { message } = error as { message: any };
         throw new ApolloError(
           'An error occurred while fetching invitations by query.',
           'INTERNAL_SERVER_ERROR',
-          {
-            detailedMessage: message.toString(),
-          }
-        )
+          { detailedMessage: message.toString() }
+        );
       }
     },
 
-    async getAllInvitations(_: any, args: { limit: number; offset: number;orgToken: string  }) {
+    async getAllInvitations(
+      _: any,
+      args: { limit?: number; offset?: number; orgToken: string; sortBy?: 1 | -1 }
+    ) {
       try {
-        const { limit = 3, offset = 0, orgToken } = args;
-        if (!orgToken) throw new GraphQLError('No organization token provided'); 
+        const { limit = 3, offset = 0, orgToken, sortBy = -1 } = args;
+    
+        if (!orgToken) throw new GraphQLError('No organization token provided');
+    
         const org = (await checkLoggedInOrganization(orgToken)).name.toLocaleLowerCase();
         const invitations = await Invitation.find({ orgName: org })
+          .sort({ createdAt: sortBy }) // Ensure sorting by the correct field
           .skip(offset)
           .limit(limit);
+    
         const totalInvitations = await Invitation.countDocuments({ orgName: org });
-
+    
         return {
           invitations,
           totalInvitations,
-        }
+        };
       } catch (error) {
-        const { message } = error as { message: any }
+        const { message } = error as { message: any };
         throw new ApolloError(
           'An error occurred while fetching invitations.',
           'INTERNAL_SERVER_ERROR',
-          {
-            detailedMessage: message.toString(),
-          }
-        )
+          { detailedMessage: message.toString() }
+        );
       }
     },
+    
 
     async filterInvitations(
       _: any,
-      args: { limit: number; offset: number; role: string; status: string; orgToken: string },
-      context: any 
+      args: { limit?: number; offset?: number; role?: string; status?: string; orgToken: string; sortBy?: 1 | -1 },
+      context: any
     ) {
       try {
-        const { userId } = (await checkUserLoggedIn(context))(['admin']);
-        const { orgToken, role, status, limit = 3, offset = 0 } = args;
+        const { userId } = await (await checkUserLoggedIn(context))(['admin']);
+        const { orgToken, role, status, limit = 5, offset = 0, sortBy = -1 } = args;
     
-        if (!userId) {
-          throw new GraphQLError('User id not provided');
-        }
-    
+        if (!userId) throw new GraphQLError('User ID not provided');
         const user = await User.findById(userId);
-        if (!user) {
-          throw new GraphQLError('User not found');
-        }
+        if (!user) throw new GraphQLError('User not found');
+        if (!orgToken) throw new GraphQLError('Organization token not provided');
     
-        if (!orgToken) {
-          throw new GraphQLError('Organization token not provided');
-        }
         const org = await checkLoggedInOrganization(orgToken);
-        if (!org) {
-          throw new GraphQLError('Organization not found');
-        }
+        if (!org) throw new GraphQLError('Organization not found');
     
-        if (!role && !status) throw new GraphQLError('No filter criteria provided');
+        // Build the filter criteria dynamically
+        const criteria: any = { orgName: { $regex: org.name, $options: 'i' } };
+        if (role) criteria['invitees.role'] = { $regex: role, $options: 'i' };
+        if (status) criteria['status'] = { $regex: status, $options: 'i' };
     
-        // Original criteria
-        const criteria = {
-          $and: [
-            { orgName: { $regex: org.name, $options: 'i' } },
-            {
-              $and: [
-                { 'invitees.role': { $regex: role, $options: 'i' } },
-                { status: { $regex: status, $options: 'i' } },
-              ],
-            },
-          ],
-        };
-    
-        let invitations: any = [];
-
-        const totalInvitations = await Invitation.countDocuments(criteria);
-    
-        // OUR TRUE LOGIC
-        if (role && status) {
-        invitations = await Invitation.find(criteria)
+        // Fetch the filtered and sorted invitations
+        const invitations = await Invitation.find(criteria)
+          .sort({ createdAt: sortBy })
           .skip(offset)
           .limit(limit);
     
-      } else if (role) {
-        invitations = await Invitation.find({           
-          $and: [
-          { orgName: { $regex: org.name, $options: 'i' } },
-          {'invitees.role': { $regex: role, $options: 'i' } }
-          ]})
-         .skip(offset)
-         .limit(limit);
-
-      } else if (status) {
-        invitations = await Invitation.find({
-          $and: [
-            { orgName: { $regex: org.name, $options: 'i' }  },
-            { status: { $regex: status, $options: 'i' } },
-          ],
-        })
-         .skip(offset)
-         .limit(limit);
-      }
-
-      return {
-        invitations,
-        totalInvitations,
-      };
-      } catch (error) {
-        const { message } = error as { message: any };
+        const totalInvitations = await Invitation.countDocuments(criteria);
     
-        if (error instanceof GraphQLError) {
-          throw error;
-        }
+        return {
+          invitations,
+          totalInvitations,
+        };
+      } catch (error) {
+        const { message } = error as { message: string };
+        if (error instanceof GraphQLError) throw error;
     
         throw new ApolloError(
           'An error occurred while fetching invitations.',
           'INTERNAL_SERVER_ERROR',
-          {
-            detailedMessage: message.toString(),
-          }
+          { detailedMessage: message }
         );
       }
-    }            
+    }
+    
   },
   Mutation: {},
-}
+};
 
-export default TableViewInvitationResolver
+export default TableViewInvitationResolver;

--- a/src/schema/invitation.schema.ts
+++ b/src/schema/invitation.schema.ts
@@ -53,11 +53,11 @@ const invitationSchema = gql`
   }
 
   type Query {
-    getAllInvitations(orgToken: String!,limit: Int, offset: Int): PaginatedInvitations!
+    getAllInvitations(orgToken: String!,limit: Int, offset: Int,sortBy:Int): PaginatedInvitations!
   }
 
     type Query {
-    filterInvitations(limit: Int, offset: Int, role: String, status: String, orgToken: String!): PaginatedInvitations!
+    filterInvitations(limit: Int, offset: Int, role: String, status: String, orgToken: String!,sortBy:Int): PaginatedInvitations!
   }
 
   type InvitationResult {


### PR DESCRIPTION
## PR Description
This pull request implements sorting functionality for invitations, ensuring they can be ordered in both descending and ascending order based on the createdAt field. Additionally, the default behavior now ensures that the latest invitations are shown first.
## Description of tasks that were expected to be completed

- [x] Enable sorting in both descending and ascending order
- [x] Set the default sorting to descending 

## How has this been tested?

- Follow this link https://devpulse-backend-pr-367.onrender.com/
- Sign in as an admin with password: Test@12345 and email: [devpulse@proton.me](mailto:devpulse@proton.me)
- Navigate to invitations.
- Sort the invitation according to the latest or old one in the invitation table.

## Screenshots (If appropriate)
(Images)
  