### PR TITLE
#318 Add request approve link to org email

### DIFF
--- a/src/helpers/user.helpers.ts
+++ b/src/helpers/user.helpers.ts
@@ -15,6 +15,11 @@ export const generateTokenOrganization = (name: string) => {
   return jwt.sign({ name }, SECRET, { expiresIn: '336h' })
 }
 
+ export const genericToken=(playLoad:any)=>{
+   return jwt.sign({...playLoad},SECRET)
+ }
+
+
 export const emailExpression =
   /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
 

--- a/src/resolvers/userResolver.ts
+++ b/src/resolvers/userResolver.ts
@@ -15,6 +15,7 @@ import {
   generateToken,
   generateTokenOrganization,
   generateTokenUserExists,
+  genericToken,
 } from '../helpers/user.helpers'
 import Cohort from '../models/cohort.model'
 import { Invitation } from '../models/invitation.model'
@@ -815,17 +816,19 @@ const resolvers: any = {
           })
 
           // Create the organization with 'pending' status
-          await Organization.create({
+const {name:nm,admin:adm,description:desc}=await Organization.create({
             admin: newAdmin._id,
             name,
             description,
             status: 'pending',
           })
+          const newOrgToken=genericToken({nm,adm,desc,email})
 
           const superAdmin = await User.find({ role: RoleOfUser.SUPER_ADMIN })
           // Get the email content
-          const content = registrationRequest(email, name, description)
-          const link = process.env.FRONTEND_LINK
+          const link = process.env.FRONTEND_LINK ?? ""
+          const content = registrationRequest(email, name, description,link,newOrgToken)
+         
 
           // Send registration request email to super admin
           await sendEmail(

--- a/src/utils/templates/registrationRequestTemplate.ts
+++ b/src/utils/templates/registrationRequestTemplate.ts
@@ -1,7 +1,8 @@
 export default function registrationRequest(
   email: string,
   name: string,
-  description: string
+  description: string,
+  link:string,newOrgToken:string
 ) {
   return `
     <table 
@@ -46,7 +47,13 @@ export default function registrationRequest(
           </div>
         </td>
       </tr>
-
+       <tr>
+       <td style="padding:20px;">
+      <a  href="${link}/organizations?newOrgToken=${newOrgToken}" style="text-decoration:none" >
+       <button style="padding:10px 15px; background-color:#004aad; color:white; border-radius:5px;cursor:pointer ;border:none">Approve</button>
+       </a>
+       </td>
+       </tr>
       <tr>
         <td style="background-color: #004aad; padding: 20px; text-align: center; border-bottom-left-radius: 8px; border-bottom-right-radius: 8px;">
           <p style="font-size: 14px; color: #ffffff;">


### PR DESCRIPTION
### PR Description
This pr adds a  link to  org request email template from which admin can be redirected to approving  the request.
### Description of tasks that were expected to be completed
  Add a  link to  org request email template from which admin can be redirected to approving  the request.
completed task.
### How has this been tested?

- clone this branch to your local machine
- install dependencies
- run the project
- test functionalities using  the frontend of dev-pulse
  login with  **email**:samuel.nishimwe@andela.com;
                      **password**: Test@12345
**pr preview link**
https://devpulse-backend-pr-395.onrender.com/
### Track PR
Trello Link (#318)
### Screenshots (If appropriate)
(Images)
  ![Screenshot from 2024-10-28 10-22-59](https://github.com/user-attachments/assets/85259f0e-7666-42b5-824d-f937e58094fb)