### PR TITLE
#392 Limit TTL to only of One Team Assignment

### DIFF
--- a/src/resolvers/team.resolvers.ts
+++ b/src/resolvers/team.resolvers.ts
@@ -308,6 +308,14 @@ const resolvers = {
             },
           })
         }
+        
+        if (ttlExist.team) {
+          throw new GraphQLError(`TTl with ${ttlEmail} already has a team`, {
+            extensions: {
+              code: 'VALIDATION_ERROR',
+            },
+          })
+        }
 
         const org = new Team({
           name,


### PR DESCRIPTION
### PR Description
Please include a brief description of the pull request you want to raise.
- Limit TTL to only of One Team Assignment
### Description of tasks that were expected to be completed
List all the tasks and sub-tasks that were assigned to you or that you assigned yourself. Make sure you check evey completed task.

- As an admin,
- I want TTLs to be restricted to only one team assignment,
- so that team management remains organized and the TTL workload is managed

- When assigning a TTL new team while he/she already has one, I should be notified that he/she already has an active team

### Functionality
How does this works, add some information that maybe needed in testing
### How has this been tested?

USe the link https://devpulse-backend-pr-403.onrender.com

- Login as and admin with email: devpulse@proton.me, password: Test@12345
- try to add team on teams page
- on ttl email try to put current active ttl email who has a team
- an error will be shown

Please describe the tests that you ran to verify your functionalities. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
### PR Checklist:
- [ ] Task 1.
- [ ] Task 2.
- [ ] Task 3.
- [ ] Task n.
### Track PR
Trello Link (#DP-?)
### Screenshots (If appropriate):
![image](https://github.com/user-attachments/assets/40e9af03-f048-4f15-a80f-40150491ffdc)

(Images)
  