### PR TITLE
ft admin dashboard: Add Time user joined to an Organisation

### DIFF
--- a/src/resolvers/profileResolver.ts
+++ b/src/resolvers/profileResolver.ts
@@ -47,22 +47,24 @@ const profileResolvers: any = {
             RoleOfUser.TTL,
           ],
         },
-      }).populate({
-        path: 'team',
-        strictPopulate: false,
-        populate: {
-          path: 'cohort',
+      })
+        .select('id email role status createdAt updatedAt')
+        .populate({
+          path: 'team',
           strictPopulate: false,
           populate: {
-            path: 'program',
+            path: 'cohort',
             strictPopulate: false,
             populate: {
-              path: 'organization',
+              path: 'program',
               strictPopulate: false,
+              populate: {
+                path: 'organization',
+                strictPopulate: false,
+              },
             },
           },
-        },
-      })
+        })
       return users
     },
     async getAllRoles() {

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -82,6 +82,8 @@ const Schema = gql`
     ratings: [Rating]
     twoFactorAuth: Boolean!
     TwoWayVerificationToken: String
+    createdAt: String
+    updatedAt: String
   }
   input RegisterInput {
     email: String!


### PR DESCRIPTION
### PR Description 
This PR adds 'created at' and 'updated at' to `getAllUsers` querry for us to be able to track user growth in an Organisation for Admin
### Functionality
- Clone the Repository and `cd` into this branch
- do `npm i`
- run the server on both backend and frontend

### How has this been tested?

 make sure that server on frontend is running, frontend branch:  `ft-main-admin-dashboard`

### Screenshots (If appropriate)

![image](https://github.com/user-attachments/assets/15e6fa2f-0ddc-4867-8ec9-6d4c5794bb18)


  